### PR TITLE
MAJOR: MkModels Update 

### DIFF
--- a/public/mkfiles/mkfiles.css
+++ b/public/mkfiles/mkfiles.css
@@ -401,7 +401,7 @@
 }
 
 .color-node-fixation-config div.jsoneditor-field {
-  background-color: #FDFDFA;
+  background-color: #FFFF99;
 }
 
 .color-node-sample div.jsoneditor-field {

--- a/public/mkturk/index.js
+++ b/public/mkturk/index.js
@@ -128,26 +128,6 @@ if (ENV.BatteryAPIAvailable) {
       .addEventListener('click', blescaleconnect, false);
 		//---- (END) for Safari
   }
-
-	// document.querySelector("button[id=doneEditingParams]").addEventListener(
-	// 	'pointerup',doneEditingParams_listener,false)
-	// document.querySelector("button[id=doneTestingTask]").addEventListener(
-	// 	'pointerup',doneTestingTask_listener,false)
-	// document.querySelector("button[id=stressTest]").addEventListener(
-	// 	'touchstart',stressTest_listener,false)
-	// document.querySelector("button[id=gridPoints]").addEventListener(
-	// 	'touchstart',gridPoints_listener,false)
-
-	// 	//---- for Safari
-	// 	document.querySelector("button[id=doneEditingParams]").addEventListener(
-	// 		'click',doneEditingParams_listener,false)
-	// 	document.querySelector("button[id=doneTestingTask]").addEventListener(
-	// 		'click',doneTestingTask_listener,false)
-	// 	document.querySelector("button[id=stressTest]").addEventListener(
-	// 		'click',stressTest_listener,false)
-	// 	document.querySelector("button[id=gridPoints]").addEventListener(
-	// 		'click',gridPoints_listener,false)
-  // 	//---- (END) for Safari
   
   document.querySelector("button[id=doneEditingParams]")
     .addEventListener('pointerup', doneEditingParams_listener, false);
@@ -1128,6 +1108,7 @@ if (ENV.BatteryAPIAvailable) {
       let touchhold_return; 
       if (FLAGS.stressTest == 1) { //IF automated stress test
         if (TASK.Species == 'model') {
+          
           let ctx = mkm.cvs.getContext('2d');
           ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
 
@@ -1173,6 +1154,7 @@ if (ENV.BatteryAPIAvailable) {
           let scaledFeature = subtracted.divNoNan(moments.variance);
           scaledFeature.print();
           if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
+            console.log('CURRTRIAL.num:', CURRTRIAL.num);
             mkm.dataObj.xTrain.push(feature);
             if (CURRTRIAL.correctitem == 0) {
               mkm.dataObj.yTrain.push([-1]);
@@ -1472,6 +1454,7 @@ if (ENV.BatteryAPIAvailable) {
           CURRTRIAL.sequencetaskscreen,
           CURRTRIAL.sequencelabel,
           CURRTRIAL.sequenceindex,
+          mkm
         );
       }
 

--- a/public/mkturk/index.js
+++ b/public/mkturk/index.js
@@ -1545,9 +1545,9 @@ if (ENV.BatteryAPIAvailable) {
             let yPred = [];
             if (TASK.SameDifferent > 0) {
               mkm.dataObj.xTest.forEach(feature => {
-                let pred = mkm.model.predict(feature.reshape([1, 2048]));
+                let pred = mkm.model.predict(feature.reshape([1, mkm.inputShape[0]]));
                 pred.print();
-                pred = pred.reshape([2]).argMax(0);
+                pred = pred.reshape([mkm.units]).argMax(0);
                 pred = pred.dataSync();
                 yPred.push(pred[0]);
               });
@@ -1559,9 +1559,9 @@ if (ENV.BatteryAPIAvailable) {
               }
             } else {
               mkm.dataObj.xTest.forEach(feature => {
-                let pred = mkm.model.predict(feature.reshape([1, 2048]));
+                let pred = mkm.model.predict(feature.reshape([1, mkm.inputShape[0]]));
                 pred.print();
-                pred = pred.reshape([2]).argMax(0);
+                pred = pred.reshape([mkm.units]).argMax(0);
                 pred = pred.dataSync();
                 yPred.push(pred[0]);
               });

--- a/public/mkturk/index.js
+++ b/public/mkturk/index.js
@@ -440,7 +440,8 @@ if (ENV.BatteryAPIAvailable) {
 		await mkm.loadFeatureExtractor(TASK.ModelConfig.modelURL, { fromTFHub: fromTFHub });
 		let cvs = document.getElementById('model-canvas');
 		mkm.bindCanvasElement(cvs);
-		mkm.buildClassifier(TASK.ModelConfig);
+		// mkm.buildClassifier(TASK.ModelConfig);
+    mkm.buildSvmClassifier(TASK.ModelConfig);
 	}
   // ======================== (END) LOAD MKMODELS ========================//
 
@@ -1167,12 +1168,18 @@ if (ENV.BatteryAPIAvailable) {
           let tensor = mkm.normalizePixelValues(mkm.cvs);
           let feature = mkm.featureExtractor.execute(tensor);
           feature = feature.reshape([2048]);
+          let moments = tf.moments(feature);
+          let subtracted = feature.sub(moments.mean);
+          let scaledFeature = subtracted.divNoNan(moments.variance);
+          scaledFeature.print();
           if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
             mkm.dataObj.xTrain.push(feature);
             if (CURRTRIAL.correctitem == 0) {
-              mkm.dataObj.yTrain.push([1, 0]);
+              mkm.dataObj.yTrain.push([-1]);
+              // mkm.dataObj.yTrain.push([1, 0]);
             } else if (CURRTRIAL.correctitem == 1) {
-              mkm.dataObj.yTrain.push([0, 1]);
+              mkm.dataObj.yTrain.push([1]);
+              // mkm.dataObj.yTrain.push([0, 1]);
             }
           } else {
             mkm.dataObj.xTest = feature;
@@ -1555,10 +1562,10 @@ if (ENV.BatteryAPIAvailable) {
           if (CURRTRIAL.num > TASK.ModelConfig.trainIdx) {
             let yPred = mkm.model.predict(mkm.dataObj.xTest.reshape([1, 2048]));
             yPred.print();
-					  yPred = yPred.reshape([2]).argMax(0);
-					  yPred = yPred.dataSync();
-					  currchoice = yPred[0];
-            console.log('yPred:', currchoice, 'yTrue:', CURRTRIAL.correctitem);
+					  // yPred = yPred.reshape([2]).argMax(0);
+					  // yPred = yPred.dataSync();
+					  // currchoice = yPred[0];
+            // console.log('yPred:', currchoice, 'yTrue:', CURRTRIAL.correctitem);
             
             if (TASK.ModelConfig.saveImages == 1) {
               if (currchoice != CURRTRIAL.correctitem) {

--- a/public/mkturk/index.js
+++ b/public/mkturk/index.js
@@ -415,6 +415,7 @@ if (ENV.BatteryAPIAvailable) {
   // =================== LOAD MKMODELS IF SPECIES = MODEL =================//
 	let mkm;
 	if (TASK.Species == 'model') {
+    TASK.PunishTimeOut = 0;
 		mkm = new MkModels();
 		let fromTFHub = TASK.ModelConfig.modelURL.includes('tfhub');
 		await mkm.loadFeatureExtractor(TASK.ModelConfig.modelURL, { fromTFHub: fromTFHub });
@@ -1024,7 +1025,7 @@ if (ENV.BatteryAPIAvailable) {
         // Render fixation screen
         if (TASK.Species == 'macaque' || TASK.Species == 'human') {
           ENV.FixationColor = 'white';
-        } else if (TASK.Species == 'marmoset') {
+        } else if (TASK.Species == 'marmoset' || TASK.Species == 'model') {
           ENV.FixationColor = 'blue';
         }
         frame.shown = [];
@@ -1074,6 +1075,7 @@ if (ENV.BatteryAPIAvailable) {
           CANVAS.sequencepre,
           [0],
           [0],
+          mkm
         );
       } else if (TASK.FixationUsesSample > 0) { // IF FixationUsesSample, show image/movie
         displayTrial(
@@ -1083,6 +1085,7 @@ if (ENV.BatteryAPIAvailable) {
           CURRTRIAL.sequencetaskscreen,
           CURRTRIAL.sequencelabel,
           CURRTRIAL.sequenceindex,
+          mkm
         );
         await moviestart_promise();
       }
@@ -1109,41 +1112,41 @@ if (ENV.BatteryAPIAvailable) {
       if (FLAGS.stressTest == 1) { //IF automated stress test
         if (TASK.Species == 'model') {
           
-          let ctx = mkm.cvs.getContext('2d');
-          ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
+          // let ctx = mkm.cvs.getContext('2d');
+          // ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
 
           touchhold_return = { type: 'theld' };
-          let sxOffset = (
-            IMAGES.Sample[CURRTRIAL.correctitem].IMAGES.sizeInches
-            * ENV.PhysicalPPI
-            / ENV.ScreenRatio
-          );
+          // let sxOffset = (
+          //   IMAGES.Sample[CURRTRIAL.correctitem].IMAGES.sizeInches
+          //   * ENV.PhysicalPPI
+          //   / ENV.ScreenRatio
+          // );
 
-          let sx = (
-            boundingBoxesFixation.x[0][1]
-            + boundingBoxesFixation.x[0][0]
-            - sxOffset
-          );
-          sx = Math.round(sx);
+          // let sx = (
+          //   boundingBoxesFixation.x[0][1]
+          //   + boundingBoxesFixation.x[0][0]
+          //   - sxOffset
+          // );
+          // sx = Math.round(sx);
 
-          let syOffset = (
-            IMAGES.Sample[CURRTRIAL.correctitem].IMAGES.sizeInches
-            * ENV.PhysicalPPI 
-            / ENV.ScreenRatio
-            - ENV.FixationWindowRadius
-          );
-          let sy = (
-            (boundingBoxesFixation.y[0][1] + boundingBoxesFixation.y[0][0]) 
-            / ENV.ScreenRatio 
-            - syOffset
-          );
-          sy = Math.round(sy);
+          // let syOffset = (
+          //   IMAGES.Sample[CURRTRIAL.correctitem].IMAGES.sizeInches
+          //   * ENV.PhysicalPPI 
+          //   / ENV.ScreenRatio
+          //   - ENV.FixationWindowRadius
+          // );
+          // let sy = (
+          //   (boundingBoxesFixation.y[0][1] + boundingBoxesFixation.y[0][0]) 
+          //   / ENV.ScreenRatio 
+          //   - syOffset
+          // );
+          // sy = Math.round(sy);
 
-          let sHeight = Math.round(
-            IMAGES.Sample[CURRTRIAL.correctitem].IMAGES.sizeInches
-            * ENV.PhysicalPPI
-          );
-          let sWidth = sHeight;
+          // let sHeight = Math.round(
+          //   IMAGES.Sample[CURRTRIAL.correctitem].IMAGES.sizeInches
+          //   * ENV.PhysicalPPI
+          // );
+          // let sWidth = sHeight;
 
           ctx.drawImage(VISIBLECANVAS, sx, sy, sWidth, sHeight, 0, 0, 224, 224);
           let tensor = mkm.normalizePixelValues(mkm.cvs);
@@ -1301,6 +1304,7 @@ if (ENV.BatteryAPIAvailable) {
           CANVAS.sequenceblank,
           [0, 0],
           [0, 0],
+          mkm
         );
       }
     }//WHILE waiting for NFixations
@@ -1402,6 +1406,7 @@ if (ENV.BatteryAPIAvailable) {
           CURRTRIAL.sequencetaskscreen,
           CURRTRIAL.sequencelabel,
           CURRTRIAL.sequenceindex,
+          mkm
         );
         CURRTRIAL.samplestarttime = Date.now() - ENV.CurrentDate.valueOf();
         CURRTRIAL.samplestarttime_string = new Date(CURRTRIAL.samplestarttime).toJSON();
@@ -1763,6 +1768,7 @@ if (ENV.BatteryAPIAvailable) {
 				CANVAS.sequencepost,
 				Array(lenTsequencePost).fill(0),
 				Array(lenTsequencePost).fill(0),
+        mkm
       );
     } else if (CURRTRIAL.correct) { // ELSE IF correct, then REWARD
       CANVAS.sequencepost[1] = "reward";
@@ -1788,7 +1794,8 @@ if (ENV.BatteryAPIAvailable) {
 					range(0, lenTsequencePost - 1, 1),
 					CANVAS.sequencepost,
 					Array(lenTsequencePost).fill(0),
-					Array(lenTsequencePost).fill(0)
+					Array(lenTsequencePost).fill(0),
+          mkm
         );
 
         if (ble.connected == false && port.connected == false) {
@@ -1823,6 +1830,7 @@ if (ENV.BatteryAPIAvailable) {
 				CANVAS.sequencepost,
 				Array(lenSequencepost).fill(0),
         Array(lenSequencepost).fill(0),
+        mkm
       );
 
       let numTrialsToBufferPunishPeriod = 50;

--- a/public/mkturk/index.js
+++ b/public/mkturk/index.js
@@ -1116,37 +1116,7 @@ if (ENV.BatteryAPIAvailable) {
           // ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
 
           touchhold_return = { type: 'theld' };
-          // let sxOffset = (
-          //   IMAGES.Sample[CURRTRIAL.correctitem].IMAGES.sizeInches
-          //   * ENV.PhysicalPPI
-          //   / ENV.ScreenRatio
-          // );
-
-          // let sx = (
-          //   boundingBoxesFixation.x[0][1]
-          //   + boundingBoxesFixation.x[0][0]
-          //   - sxOffset
-          // );
-          // sx = Math.round(sx);
-
-          // let syOffset = (
-          //   IMAGES.Sample[CURRTRIAL.correctitem].IMAGES.sizeInches
-          //   * ENV.PhysicalPPI 
-          //   / ENV.ScreenRatio
-          //   - ENV.FixationWindowRadius
-          // );
-          // let sy = (
-          //   (boundingBoxesFixation.y[0][1] + boundingBoxesFixation.y[0][0]) 
-          //   / ENV.ScreenRatio 
-          //   - syOffset
-          // );
-          // sy = Math.round(sy);
-
-          // let sHeight = Math.round(
-          //   IMAGES.Sample[CURRTRIAL.correctitem].IMAGES.sizeInches
-          //   * ENV.PhysicalPPI
-          // );
-          // let sWidth = sHeight;
+          
 
           ctx.drawImage(VISIBLECANVAS, sx, sy, sWidth, sHeight, 0, 0, 224, 224);
           let tensor = mkm.normalizePixelValues(mkm.cvs);

--- a/public/mkturk/index.js
+++ b/public/mkturk/index.js
@@ -1498,6 +1498,10 @@ if (ENV.BatteryAPIAvailable) {
           y = 0;
 
           if (CURRTRIAL.num == TASK.ModelConfig.trainIdx) {
+            let yTrainLabel0 = mkm.dataObj.yTrainLabels.filter(x => x === 0).length;
+            let yTrainLabel1 = mkm.dataObj.yTrainLabels.filter(x => x === 1).length;
+            console.log('yTrainLabels:', mkm.dataObj.yTrainLabels, 'Label 0:', yTrainLabel0, 'Label 1:', yTrainLabel1);
+
             let xTrain = tf.data.array(mkm.dataObj.xTrain);
             let yTrain = tf.data.array(mkm.dataObj.yTrain);
             let trainDataset = tf.data.zip({ xs: xTrain, ys: yTrain })

--- a/public/mkturk/mkmodels.js
+++ b/public/mkturk/mkmodels.js
@@ -22,12 +22,20 @@ class MkModels {
   }
 
   normalizePixelValues(canvas) {
-    let offset = tf.scalar(127.5);
+    // let offset = tf.scalar(127.5);
+    // let tensor = (
+    //   tf.browser.fromPixels(canvas)
+    //     .resizeNearestNeighbor([224, 224])
+    //     .toFloat()
+    //     .sub(offset)
+    //     .div(offset)
+    //     .expandDims()
+    // );
+    let offset = tf.scalar(255.0);
     let tensor = (
       tf.browser.fromPixels(canvas)
         .resizeNearestNeighbor([224, 224])
         .toFloat()
-        .sub(offset)
         .div(offset)
         .expandDims()
     );
@@ -85,7 +93,7 @@ class MkModels {
       srcY = (params.boundingBoxes2D.y[0][0] - params.offsettop) * params.ScreenRatio;
       if (Array.isArray(params.image.sizeInches)) {
         srcWidth = Math.round(
-          params.image.sizeInches[0]
+          Math.max(...params.image.sizeInches)
           * params.ViewportPPI
           * params.ScreenRatio
         );
@@ -100,8 +108,11 @@ class MkModels {
     } else { // NO background image. 
       let offsetX;
       if (Array.isArray(params.object[Object.keys(params.object)[0]].sizeInches)) {
+        // offsetX = (
+        //   params.object[Object.keys(params.object)[0]].sizeInches[params.idx] * params.ViewportPPI
+        // );
         offsetX = (
-          params.object[Object.keys(params.object)[0]].sizeInches[params.idx] * params.ViewportPPI
+          Math.max(...params.object[Object.keys(params.object)[0]].sizeInches) * params.ViewportPPI
         );
       } else {
         offsetX = (

--- a/public/mkturk/mkmodels.js
+++ b/public/mkturk/mkmodels.js
@@ -75,5 +75,55 @@ class MkModels {
     this.model.summary();
   }
 
+  getMkModelBoundingBox(params) {
+    let srcX, srcY, srcWidth, srcHeight;
+    if (!params.image.imageidx.includes(NaN)) { // IF background image
+      srcX = params.boundingBoxes2D.x[0][0] * params.ScreenRatio;
+      srcY = (params.boundingBoxes2D.y[0][0] - params.offsettop) * params.ScreenRatio;
+      if (Array.isArray(params.image.sizeInches)) {
+        srcWidth = Math.round(
+          params.image.sizeInches[0]
+          * params.ViewportPPI
+          * params.ScreenRatio
+        );
+      } else {
+        srcWidth = Math.round(
+          params.image.sizeInches
+          * params.ViewportPPI
+          * params.ScreenRatio
+        );
+      }
+      srcHeight = srcWidth;
+    } else { // NO background image. 
+      let offsetX;
+      if (Array.isArray(params.object[Object.keys(params.object)[0]].sizeInches)) {
+        offsetX = (
+          params.object[Object.keys(params.object)[0]].sizeInches[params.idx] * params.ViewportPPI
+        );
+      } else {
+        offsetX = (
+          params.object[Object.keys(params.object)[0]].sizeInches * params.ViewportPPI
+        );
+      }
+      let offsetY = offsetX;
+      srcX = (
+        params.boundingBoxes3D.x[0][0]
+        + params.boundingBoxes3D.x[0][1]
+        - offsetX
+      );
+      
+      srcY = (
+        (boundingBoxes3D.y[0][0] - params.offsettop)
+        + (boundingBoxes3D.y[0][1] - params.offsettop)
+        - offsetY
+      );
+
+      srcHeight = Math.round(offsetX * params.ScreenRatio);
+      srcWidth = srcHeight;
+    }
+
+    return { sx: srcX, sy: srcY, sWidth: srcWidth, sHeight: srcHeight };
+  }
+
 
 }

--- a/public/mkturk/mkmodels.js
+++ b/public/mkturk/mkmodels.js
@@ -5,6 +5,8 @@ class MkModels {
     this.dataObj = {};
     this.dataObj.xTrain = [];
     this.dataObj.yTrain = [];
+    this.dataObj.xTest = [];
+    this.dataObj.yTest = [];
     this.cvs;
     this.hasSampleFeatures = false;
     this.hasTestFeatures = false;

--- a/public/mkturk/mkmodels.js
+++ b/public/mkturk/mkmodels.js
@@ -44,5 +44,34 @@ class MkModels {
     this.model.summary();
   }
 
+  buildSvmClassifier(config) {
+    this.model = tf.sequential();
+    this.model.add(tf.layers.dense({
+      units: 1,
+      inputShape: [config.inputShape],
+      activation: 'linear',
+      kernelRegularizer: tf.regularizers.l2(),
+    }));
+
+    function hingeLoss(yTrue, yPred) {
+      console.log('hinge yTrue:');
+      yTrue.print(true);
+      console.log('hinge yPred:');
+      yPred.print(true);
+      // let loss = tf.maximum(0., 1 - yTrue * yPred);
+      let loss = tf.losses.hingeLoss(yTrue, yPred);
+      console.log('hinge loss:');
+      loss.print(true);
+      return loss;
+    }
+
+    this.model.compile({
+      optimizer: tf.train.adam(),
+      loss: hingeLoss,
+      metrics: ['accuracy']
+    });
+    this.model.summary();
+  }
+
 
 }

--- a/public/mkturk/mkmodels.js
+++ b/public/mkturk/mkmodels.js
@@ -14,6 +14,7 @@ class MkModels {
     this.inputShape; // inputShape (number[]);
     this.units; // units (number);
     this.oneHotArr;
+    this.outputNode;
     // this.loss; // loss (string): 'categoricalCrossentropy'|'binaryCrossentropy';
     // this.activation; // activation (string): 'softmax'|'sigmoid';
     // this.optimizer;
@@ -62,6 +63,7 @@ class MkModels {
     if (config.mode == 'default') {
       let loss = (this.units > 2) ? 'categoricalCrossentropy' : 'binaryCrossentropy';
       let activation = (this.units > 2) ? 'softmax' : 'sigmoid';
+      this.outputNode = '';
       this.model.add(tf.layers.dense({
         units: this.units,
         inputShape: this.inputShape,
@@ -80,6 +82,10 @@ class MkModels {
       );
       this.units = (
         configKeys.includes('imageBagsTrainIdxs') ? config['imageBagTrainIdxs'].length : this.units
+      );
+
+      this.outputNode = (
+        configKeys.includes('outputNode') ? config.outputNode : ''
       );
 
       let activation;
@@ -109,17 +115,6 @@ class MkModels {
       this.model.summary();
     }
     this.oneHotArr = this.createOneHot(this.units);
-    // this.model.add(tf.layers.dense({
-    //   units: config.outputUnits,
-    //   inputShape: [config.inputShape],
-    //   activation: config.activation
-    // }));
-    // this.model.compile({
-    //   optimizer: tf.train.adam(),
-    //   loss: config.loss,
-    //   metrics: ['accuracy']
-    // });
-    // this.model.summary();
   }
 
   buildSvmClassifier(config) {

--- a/public/mkturk/mkmodels.js
+++ b/public/mkturk/mkmodels.js
@@ -6,6 +6,8 @@ class MkModels {
     this.dataObj.xTrain = [];
     this.dataObj.yTrain = [];
     this.cvs;
+    this.hasSampleFeatures = false;
+    this.hasTestFeatures = false;
   }
 
   bindCanvasElement(canvas) {

--- a/public/mkturk/mkmodels.js
+++ b/public/mkturk/mkmodels.js
@@ -13,6 +13,7 @@ class MkModels {
     this.hasTestFeatures = false;
     this.inputShape; // inputShape (number[]);
     this.units; // units (number);
+    this.oneHotArr;
     // this.loss; // loss (string): 'categoricalCrossentropy'|'binaryCrossentropy';
     // this.activation; // activation (string): 'softmax'|'sigmoid';
     // this.optimizer;
@@ -80,6 +81,7 @@ class MkModels {
       this.units = (
         configKeys.includes('imageBagsTrainIdxs') ? config['imageBagTrainIdxs'].length : this.units
       );
+
       let activation;
       let loss;
       if (configKeys.includes('activation')) {
@@ -105,7 +107,8 @@ class MkModels {
         metrics: ['accuracy']
       });
       this.model.summary();
-    } 
+    }
+    this.oneHotArr = this.createOneHot(this.units);
     // this.model.add(tf.layers.dense({
     //   units: config.outputUnits,
     //   inputShape: [config.inputShape],
@@ -150,7 +153,7 @@ class MkModels {
 
   getMkModelBoundingBox(params) {
     let srcX, srcY, srcWidth, srcHeight;
-    if (!params.image.imageidx.includes(NaN) && params.image.imagebag) { // IF background image
+    if (!params.image.imageidx.includes(NaN) && !params.image.imageidx[0].includes(NaN) && params.image.imagebag) { // IF background image
       srcX = params.boundingBoxes2D.x[0][0] * params.ScreenRatio;
       srcY = (params.boundingBoxes2D.y[0][0] - params.offsettop) * params.ScreenRatio;
       if (Array.isArray(params.image.sizeInches)) {
@@ -206,6 +209,19 @@ class MkModels {
       arr.splice(idx, 1);
     }
     return arr;
+  }
+
+  createOneHot(units) {
+    let arr = [];
+    for (let i = 0; i < units; i++) {
+      arr[i] = Array(units).fill(0);
+      arr[i][i] = 1;
+    }
+    return arr;
+  }
+
+  getOneHotIdx(correctItem) {
+    return correctItem % this.units;
   }
 
 }

--- a/public/mkturk/mkmodels.js
+++ b/public/mkturk/mkmodels.js
@@ -5,6 +5,7 @@ class MkModels {
     this.dataObj = {};
     this.dataObj.xTrain = [];
     this.dataObj.yTrain = [];
+    this.dataObj.yTrainLabels = [];
     this.dataObj.xTest = [];
     this.dataObj.yTest = [];
     this.cvs;
@@ -127,5 +128,11 @@ class MkModels {
     return { sx: srcX, sy: srcY, sWidth: srcWidth, sHeight: srcHeight };
   }
 
+  removeItemOnce(arr, idx) {
+    if (idx > -1) {
+      arr.splice(idx, 1);
+    }
+    return arr;
+  }
 
 }

--- a/public/mkturk/mkmodels.js
+++ b/public/mkturk/mkmodels.js
@@ -79,7 +79,7 @@ class MkModels {
 
   getMkModelBoundingBox(params) {
     let srcX, srcY, srcWidth, srcHeight;
-    if (!params.image.imageidx.includes(NaN)) { // IF background image
+    if (!params.image.imageidx.includes(NaN) && params.image.imagebag) { // IF background image
       srcX = params.boundingBoxes2D.x[0][0] * params.ScreenRatio;
       srcY = (params.boundingBoxes2D.y[0][0] - params.offsettop) * params.ScreenRatio;
       if (Array.isArray(params.image.sizeInches)) {
@@ -115,8 +115,8 @@ class MkModels {
       );
       
       srcY = (
-        (boundingBoxes3D.y[0][0] - params.offsettop)
-        + (boundingBoxes3D.y[0][1] - params.offsettop)
+        (params.boundingBoxes3D.y[0][0] - params.offsettop)
+        + (params.boundingBoxes3D.y[0][1] - params.offsettop)
         - offsetY
       );
 

--- a/public/mkturk/mkturk_firebasestorage.js
+++ b/public/mkturk/mkturk_firebasestorage.js
@@ -235,6 +235,9 @@ async function loadParametersfromFirebase(paramfile_path){
 		data = await loadTextfromFirebase(paramfile_path)
 		TASK = {}
 		TASK = data
+		if (TASK.Species == 'model') {
+			TASK.PunishTimeOut = 0;
+		}
 		await loadAgentRFIDfromFirestore(ENV.Subject,TASK.Species)
 
 		

--- a/public/mkturk/mkturk_firebasestorage.js
+++ b/public/mkturk/mkturk_firebasestorage.js
@@ -340,28 +340,51 @@ async function saveParameterstoFirebase() {
 
 
 //------------- SAVE DATA --------------//
-async function saveBehaviorDatatoFirebase(TASK, ENV, CANVAS, EVENTS){
-	var dataobj = { 'TASK': TASK,
-					'ENV': ENV,
-					'CANVAS': CANVAS,
-					'SCENEMETA': IMAGEMETA,
-					'SCENES': { 'SampleScenes': IMAGES.Sample, 'TestScenes': IMAGES.Test },
-					'TRIALEVENTS': EVENTS['trialseries'],
-					'TIMEEVENTS': { 'Battery': EVENTS['timeseries']['Battery'],
-									'RFIDTag': EVENTS['timeseries']['RFIDTag'], 
-									'Weight': EVENTS['timeseries']['Weight'],
-									'Arduino': EVENTS['timeseries']['Arduino'],
-									'TSequenceActual': EVENTS['timeseries']['TSequenceActual']
-									 }
-	}//dataobj
-	datastr = JSON.stringify(dataobj); //no pretty print for now, saves space and data file is unwieldy to look at for larger numbers of trials
-	var blob = new Blob([ datastr ], {type : 'application/json'});
+async function saveBehaviorDatatoFirebase(TASK, ENV, CANVAS, EVENTS) {
+	let dataObj;
+	if (TASK.Species == 'model' && Object.keys(EVENTS).includes('trainseries')) {
+		dataObj = {
+			'TASK': TASK,
+			'ENV': ENV,
+			'CANVAS': CANVAS,
+			'SCENEMETA': IMAGEMETA,
+			'SCENES': { 'SampleScenes': IMAGES.Sample, 'TestScenes': IMAGES.Test },
+			'TRIALEVENTS': EVENTS['trialseries'],
+			'TIMEEVENTS': {
+				'Battery': EVENTS['timeseries']['Battery'],
+				'RFIDTag': EVENTS['timeseries']['RFIDTag'], 
+				'Weight': EVENTS['timeseries']['Weight'],
+				'Arduino': EVENTS['timeseries']['Arduino'],
+				'TSequenceActual': EVENTS['timeseries']['TSequenceActual']
+			},
+			'TRAINEVENTS': EVENTS['trainseries'],
+		};
+	} else {
+		dataObj = {
+			'TASK': TASK,
+			'ENV': ENV,
+			'CANVAS': CANVAS,
+			'SCENEMETA': IMAGEMETA,
+			'SCENES': { 'SampleScenes': IMAGES.Sample, 'TestScenes': IMAGES.Test },
+			'TRIALEVENTS': EVENTS['trialseries'],
+			'TIMEEVENTS': {
+				'Battery': EVENTS['timeseries']['Battery'],
+				'RFIDTag': EVENTS['timeseries']['RFIDTag'], 
+				'Weight': EVENTS['timeseries']['Weight'],
+				'Arduino': EVENTS['timeseries']['Arduino'],
+				'TSequenceActual': EVENTS['timeseries']['TSequenceActual']
+			}
+		}
+	}
+	
+	// let datastr = JSON.stringify(dataObj); //no pretty print for now, saves space and data file is unwieldy to look at for larger numbers of trials
+	let blob = new Blob([JSON.stringify(dataObj)], { type : 'application/json' });
 
 	// Create file metadata including the content type
-	var metadata = { contentType: 'application/json' };
+	let metadata = { contentType: 'application/json' };
 
 	// Upload the file and metadata
-	var response = await storage.ref().child(ENV.DataFileName).put(blob, metadata);
+	let response = await storage.ref().child(ENV.DataFileName).put(blob, metadata);
 	CURRTRIAL.lastFirebaseSave = new Date(response.metadata.updated)
 	console.log("FIREBASE: Save Data, " + Math.round(response.totalBytes/1000) + 'kb')
 } //UploadToFirebase

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -1,18 +1,19 @@
 //================== IMAGE RENDERING ==================//
-function displayTrial(ti,gr,fr,sc,ob,id){
+function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 	console.log('arguments.length:', arguments.length);
+	let lenArgs = arguments.length;
 	// if (arguments.length == 7) {
 	// 	console.log('mkm:', mkm);
 	// }
 // ti = time, gr = grid, fr = frame
 // sc = screen, ob = object label, id = index of renderparam
-	var resolveFunc
-	var errFunc
-	updated2d = 0
-	updated3d = 0
-	boundingBoxesChoice2D = {'x':[],'y':[]}
-	boundingBoxesChoice3JS = {'x':[],'y':[]}
-	boundingBoxesChoice3D = {'x':[],'y':[]}
+	var resolveFunc;
+	var errFunc;
+	updated2d = 0;
+	updated3d = 0;
+	boundingBoxesChoice2D = { 'x': [], 'y': [] };
+	boundingBoxesChoice3JS = { 'x': [], 'y': [] };
+	boundingBoxesChoice3D = { 'x': [], 'y': [] };
 	p = new Promise(function(resolve,reject){
 		resolveFunc = resolve;
 		errFunc = reject;
@@ -23,20 +24,20 @@ function displayTrial(ti,gr,fr,sc,ob,id){
 		
 		if (!start) start = timestamp; //IF start has not been set to a float timestamp, set it now.
 
-		if (timestamp - start > ti[frame.current]){
-			console.log('updateCanvas called');
+		if (timestamp - start > ti[frame.current]) {
+			// console.log('updateCanvas called');
 			//----- RENDER ALL ELEMENTS
-			if (!ENV.OffscreenCanvasAvailable){
-					renderShape2D('Blank',[-1],OFFSCREENCANVAS)				
+			if (!ENV.OffscreenCanvasAvailable) {
+				renderShape2D('Blank', [-1], OFFSCREENCANVAS);
 			}
 
 			for (var s = 0; s<=frame.frames[frame.current].length-1; s++){
 				f = frame.frames[frame.current][s]
 				var taskscreen = sc[f].charAt(0).toUpperCase() + sc[f].slice(1)
-				console.log('taskscreen:', taskscreen);
+				// console.log('taskscreen:', taskscreen);
 				
 				if (s==0){
-					var taskscreen0 = taskscreen
+					var taskscreen0 = taskscreen;
 				}//IF primary screen
 
 //------------------- DISPLAY THE FRAME 2D ---------------------//
@@ -109,7 +110,101 @@ function displayTrial(ti,gr,fr,sc,ob,id){
 				boundingBoxesChoice3D.y = boundingBoxesChoice3JS.y			
 			}
 
-			console.log(`taskscreen: ${taskscreen}; taskscreen0: ${taskscreen0}; boundingBoxesChoice3D: ${JSON.stringify(boundingBoxesChoice3D)}`);
+			// console.log(`taskscreen: ${taskscreen}; taskscreen0: ${taskscreen0}; boundingBoxesChoice3D: ${JSON.stringify(boundingBoxesChoice3D)}`);
+			if (taskscreen == 'Sample') {
+				console.log(`arguments.length=${lenArgs}`);
+			}
+
+			// MkModel Logic
+			
+			if (TASK.SameDifferent > 0 && lenArgs == 7) {
+				console.log('displayTrial SD');
+				if (taskscreen == 'Sample' && !mkm.hasSampleFeatures) {
+					let ctx = mkm.cvs.getContext('2d');
+					ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
+					let label = CURRTRIAL.sample_scenebag_label[0][0];
+					let sxOffset = (
+						IMAGES.Sample[label].IMAGES.sizeInches
+						* ENV.PhysicalPPI
+						/ ENV.ScreenRatio
+					);
+					let sx = Math.round(
+						boundingBoxesChoice3D.x[0][1]
+						+ boundingBoxesChoice3D.x[0][0]
+						- sxOffset
+					);
+					let syOffset = (
+						IMAGES.Sample[label].IMAGES.sizeInches
+						* ENV.PhysicalPPI
+						/ ENV.ScreenRatio
+					);
+					let sy = Math.round(
+						(boundingBoxesChoice3D.y[0][1] + boundingBoxesChoice3D.y[0][0])
+						/ ENV.ScreenRatio
+					);
+					let sHeight = Math.round(
+						IMAGES.Sample[label].IMAGES.sizeInches
+						* ENV.PhysicalPPI
+					);
+					let sWidth = sHeight;
+					console.log(`SAMPLE sx=${sx}; sy=${sy}; sWidth=${sWidth}; sHeight=${sHeight}; syOffset=${syOffset}`);
+					
+					ctx.drawImage(VISIBLECANVAS, sx, sy, sWidth, sHeight, 0, 0, 224, 224);
+					let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
+					let cvsData = mkm.cvs.toDataURL();
+					let path = (
+						`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
+					);
+					mkmodelsRef.child(path).putString(cvsData, 'data_url');
+					mkm.hasSampleFeatures = true;
+				} else if (taskscreen == 'Test' && !mkm.hasTestFeatures) {
+					let ctx = mkm.cvs.getContext('2d');
+					ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
+					let label = CURRTRIAL.test_scenebag_labels[0][0];
+					let sxOffset = (
+						IMAGES.Test[label].IMAGES.sizeInches
+						* ENV.PhysicalPPI
+						/ ENV.ScreenRatio
+					);
+					let sx = Math.round(
+						boundingBoxesChoice3D.x[0][1]
+						+ boundingBoxesChoice3D.x[0][0]
+						- sxOffset
+					);
+					let syOffset = (
+						IMAGES.Test[label].IMAGES.sizeInches
+						* ENV.PhysicalPPI
+						/ ENV.ScreenRatio
+					);
+					let sy = Math.round(
+						(boundingBoxesChoice3D.y[0][1] + boundingBoxesChoice3D.y[0][0])
+						/ ENV.ScreenRatio
+						- syOffset
+					);
+					let sHeight = Math.round(
+						IMAGES.Test[label].IMAGES.sizeInches
+						* ENV.PhysicalPPI
+					);
+					// let sHeight = 300;
+					let sWidth = sHeight;
+					console.log(`TEST sx=${sx}; sy=${sy}; sWidth=${sWidth}; sHeight=${sHeight}`);
+
+					console.log(`mkm.cvs.width=${mkm.cvs.width}; mkm.cvs.height=${mkm.cvs.height}`);
+					ctx.drawImage(VISIBLECANVAS, sx, sy, sWidth, sHeight, 0, 0, 224, 224);
+					let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
+					let cvsData = mkm.cvs.toDataURL();
+					let path = (
+						`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_test.png`
+					);
+					mkmodelsRef.child(path).putString(cvsData, 'data_url');
+					mkm.hasTestFeatures = true;
+				} else if (taskscreen == 'Choice' && mkm.hasSampleFeatures && mkm.hasTestFeatures) {
+					mkm.hasSampleFeatures = false;
+					mkm.hasTestFeatures = false;
+				}
+
+			}
+				
 
 			//----- (2) Update Status
 			updated2d = 0

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -1,9 +1,9 @@
 //================== IMAGE RENDERING ==================//
 function displayTrial(ti,gr,fr,sc,ob,id){
 	console.log('arguments.length:', arguments.length);
-	if (arguments.length == 7) {
-		console.log('mkm:', mkm);
-	}
+	// if (arguments.length == 7) {
+	// 	console.log('mkm:', mkm);
+	// }
 // ti = time, gr = grid, fr = frame
 // sc = screen, ob = object label, id = index of renderparam
 	var resolveFunc
@@ -108,6 +108,8 @@ function displayTrial(ti,gr,fr,sc,ob,id){
 				boundingBoxesChoice3D.x = boundingBoxesChoice3JS.x
 				boundingBoxesChoice3D.y = boundingBoxesChoice3JS.y			
 			}
+
+			console.log(`taskscreen: ${taskscreen}; taskscreen0: ${taskscreen0}; boundingBoxesChoice3D: ${JSON.stringify(boundingBoxesChoice3D)}`);
 
 			//----- (2) Update Status
 			updated2d = 0

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -261,8 +261,9 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						
 						ctx.drawImage(VISIBLECANVAS, mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight, 0, 0, 224, 224);
 						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs));
-						featureVec = featureVec.reshape([2048]);
-						if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
+						featureVec = featureVec.reshape(mkm.inputShape);
+						if (CURRTRIAL.num < TASK.ModelConfig.trainIdx) {
+							console.log('CURRTRIAL.num:', CURRTRIAL.num);
 							mkm.dataObj.xTrain.push(featureVec);
 							if (CURRTRIAL.correctitem == 0) {
 								mkm.dataObj.yTrainLabels.push(0);
@@ -278,12 +279,12 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 							mkm.dataObj.yTest.push(CURRTRIAL.sample_scenebag_label[0][0]);
 						}
 						// mkm.cvs SANITY CHECK CODE
-						let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
-						let cvsData = mkm.cvs.toDataURL();
-						let path = (
-							`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
-						);
-						mkmodelsRef.child(path).putString(cvsData, 'data_url');
+						// let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
+						// let cvsData = mkm.cvs.toDataURL();
+						// let path = (
+						// 	`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
+						// );
+						// mkmodelsRef.child(path).putString(cvsData, 'data_url');
 						// ctx2.clearRect(0, 0, EYETRACKERCANVAS.width, EYETRACKERCANVAS.height);
 						mkm.hasSampleFeatures = true;
 					} else if (taskscreen != 'Sample' && mkm.hasSampleFeatures) {
@@ -1219,7 +1220,7 @@ function updateHeadsUpDisplay(){
 			for (let i = TASK.ModelConfig.trainIdx + 1; i < EVENTS['trialseries']['Response'].length; i++) {
 				if (EVENTS['trialseries']['Response'][i] == EVENTS['trialseries']['CorrectItem'][i]) {
 					ncorrect = ncorrect + 1;
-					let len = EVENTS['trialseries']['Response'].length - TASK.ModelConfig.trainIdx - 1;
+					let len = EVENTS['trialseries']['Response'].length - TASK.ModelConfig.trainIdx;
 					var pctcorrect = Math.round(100 * ncorrect / len);
 				}
 			}
@@ -1246,15 +1247,14 @@ function updateHeadsUpDisplay(){
 	}
 	if (CANVAS.headsupfraction > 0){
 		if (TASK.Species == 'model') {
-			if (CURRTRIAL.num == 0) {
-
-			} else if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
+			if (CURRTRIAL.num < TASK.ModelConfig.trainIdx) {
 				// console.log('screenfunc:', EVENTS['trialseries']['Response'].length, CURRTRIAL.num, TASK.ModelConfig.trainIdx);
-				let tmp = EVENTS['trialseries']['Response'].length - 1;
+				let tmp = EVENTS['trialseries']['Response'].length;
+				let tmp2 = CURRTRIAL.num + 2;
 				textobj.innerHTML = (
 					'User: ' + ENV.ResearcherDisplayName + ', ' + ENV.ResearcherEmail + "<br>" +
 					'Agent: ' + ENV.Subject + ", <font color=green><b>" + 
-					"TRAINING</b></font> "  + '(' + tmp + ' of ' + TASK.ModelConfig.trainIdx + ')' +"<br>" +
+					"TRAINING</b></font> "  + '(' + tmp2 + ' of ' + TASK.ModelConfig.trainIdx + ')' +"<br>" +
 					task1 + "<br>" + task2 + "<br>" + "<br>" +
 					"last trial @ " + CURRTRIAL.lastTrialCompleted.toLocaleTimeString("en-US") + "<br>" +
 					"last saved to firebase @ " + CURRTRIAL.lastFirebaseSave.toLocaleTimeString("en-US")
@@ -1263,7 +1263,7 @@ function updateHeadsUpDisplay(){
 				textobj.innerHTML = (
 					'User: ' + ENV.ResearcherDisplayName + ', ' + ENV.ResearcherEmail + "<br>" +
 					'Agent: ' + ENV.Subject + ", <font color=green><b>" + pctcorrect  +
-					"%</b></font> " + "(" + ncorrect + " of " + (EVENTS['trialseries']['Response'].length - TASK.ModelConfig.trainIdx - 1) + " trials)" +
+					"%</b></font> " + "(" + ncorrect + " of " + (EVENTS['trialseries']['Response'].length - TASK.ModelConfig.trainIdx) + " trials)" +
 					"<br>" +
 					task1 + "<br>" + task2 + "<br>" + "<br>" +
 					"last trial @ " + CURRTRIAL.lastTrialCompleted.toLocaleTimeString("en-US") + "<br>" +

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -1,6 +1,5 @@
 //================== IMAGE RENDERING ==================//
 function displayTrial(ti,gr,fr,sc,ob,id,mkm){
-	console.log('arguments.length:', arguments.length);
 	let lenArgs = arguments.length;
 	// if (arguments.length == 7) {
 	// 	console.log('mkm:', mkm);
@@ -102,10 +101,12 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 //------------------- Frame is fully on display ---------------------//
 			//----- (1) Merge Bounding Boxes
 			if (updated2d){
+				console.log('updated2d');
 				boundingBoxesChoice3D.x = boundingBoxesChoice2D.x
 				boundingBoxesChoice3D.y = boundingBoxesChoice2D.y
 			}//
 			if (updated3d){
+				console.log('updated3d');
 				boundingBoxesChoice3D.x = boundingBoxesChoice3JS.x
 				boundingBoxesChoice3D.y = boundingBoxesChoice3JS.y			
 			}
@@ -128,7 +129,7 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						* ENV.PhysicalPPI
 						/ ENV.ScreenRatio
 					);
-					let sx = Math.round(
+					let sx = (
 						boundingBoxesChoice3D.x[0][1]
 						+ boundingBoxesChoice3D.x[0][0]
 						- sxOffset
@@ -138,9 +139,10 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						* ENV.PhysicalPPI
 						/ ENV.ScreenRatio
 					);
-					let sy = Math.round(
-						(boundingBoxesChoice3D.y[0][1] + boundingBoxesChoice3D.y[0][0])
+					let sy = (
+						(boundingBoxesChoice3D.y[0][1] + boundingBoxesChoice3D.y[0][0] - syOffset)
 						/ ENV.ScreenRatio
+						
 					);
 					let sHeight = Math.round(
 						IMAGES.Sample[label].IMAGES.sizeInches
@@ -148,6 +150,12 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 					);
 					let sWidth = sHeight;
 					console.log(`SAMPLE sx=${sx}; sy=${sy}; sWidth=${sWidth}; sHeight=${sHeight}; syOffset=${syOffset}`);
+					console.log('boundingBoxesChoice3D:', boundingBoxesChoice3D);
+					let visiblecvs = document.getElementById("canvaseyetracker");
+					let ctx2 = visiblecvs.getContext('2d');
+				
+					ctx2.rect(772, 674, sWidth, sHeight);
+					ctx2.stroke();
 					
 					ctx.drawImage(VISIBLECANVAS, sx, sy, sWidth, sHeight, 0, 0, 224, 224);
 					let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
@@ -166,7 +174,7 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						* ENV.PhysicalPPI
 						/ ENV.ScreenRatio
 					);
-					let sx = Math.round(
+					let sx = (
 						boundingBoxesChoice3D.x[0][1]
 						+ boundingBoxesChoice3D.x[0][0]
 						- sxOffset
@@ -176,10 +184,10 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						* ENV.PhysicalPPI
 						/ ENV.ScreenRatio
 					);
-					let sy = Math.round(
-						(boundingBoxesChoice3D.y[0][1] + boundingBoxesChoice3D.y[0][0])
+					let sy = (
+						(boundingBoxesChoice3D.y[0][1] + boundingBoxesChoice3D.y[0][0] - syOffset)
 						/ ENV.ScreenRatio
-						- syOffset
+						
 					);
 					let sHeight = Math.round(
 						IMAGES.Test[label].IMAGES.sizeInches
@@ -188,6 +196,8 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 					// let sHeight = 300;
 					let sWidth = sHeight;
 					console.log(`TEST sx=${sx}; sy=${sy}; sWidth=${sWidth}; sHeight=${sHeight}`);
+					console.log('boundingBoxesChoice3D:', boundingBoxesChoice3D);
+
 
 					console.log(`mkm.cvs.width=${mkm.cvs.width}; mkm.cvs.height=${mkm.cvs.height}`);
 					ctx.drawImage(VISIBLECANVAS, sx, sy, sWidth, sHeight, 0, 0, 224, 224);
@@ -407,6 +417,8 @@ function renderImage2D(im,sc,ob,id,fr,gr,imgFilterSingleFrame,canvasobj){
 	var ybound=[];
 	xleft = Math.round(ENV.XGridCenter[gr]/ENV.CanvasRatio - 0.5*wdpixels);
 	ytop = Math.round(ENV.YGridCenter[gr]/ENV.CanvasRatio - 0.5*htpixels);
+
+	console.log(`xleft=${xleft}, ytop=${ytop}, wdpixels=${wdpixels}, htpixels=${htpixels}`);
 			
 	context.filter = imgFilterSingleFrame
 	context.drawImage(im,xleft,ytop,wdpixels,htpixels);

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -1247,7 +1247,7 @@ function updateHeadsUpDisplay(){
 	}
 	if (CANVAS.headsupfraction > 0){
 		if (TASK.Species == 'model') {
-			if (CURRTRIAL.num < TASK.ModelConfig.trainIdx) {
+			if (CURRTRIAL.num < TASK.ModelConfig.trainIdx - 1) {
 				// console.log('screenfunc:', EVENTS['trialseries']['Response'].length, CURRTRIAL.num, TASK.ModelConfig.trainIdx);
 				let tmp = EVENTS['trialseries']['Response'].length;
 				let tmp2 = CURRTRIAL.num + 2;

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -146,6 +146,20 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						ctx.drawImage(VISIBLECANVAS, mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight, 0, 0, 224, 224);
 						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs));
 						featureVec = featureVec.reshape([2048]);
+
+						if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
+							mkm.dataObj.xTrain.push(featureVec);
+							if (CURRTRIAL.sample_scenebag_label[0][0] == 0) {
+								mkm.dataObj.yTrain.push([0]);
+								// for SVM
+								// mkm.dataObj.yTrain.push([-1])
+							} else if (CURRTRIAL.sample_scenebag_label[0][0] == 1) {
+								mkm.dataObj.yTrain.push([1]);
+							}
+						} else {
+							mkm.dataObj.xTest = featureVec;
+							mkm.dataObj.yTest = CURRTRIAL.sample_scenebag_label[0][0];
+						}
 						// mkm.cvs SANITY CHECK CODE
 						// let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
 						// let cvsData = mkm.cvs.toDataURL();
@@ -179,12 +193,38 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						// ctx2.stroke();
 						
 						ctx.drawImage(VISIBLECANVAS, mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight, 0, 0, 224, 224);
-						let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
-						let cvsData = mkm.cvs.toDataURL();
-						let path = (
-							`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_test.png`
-						);
-						mkmodelsRef.child(path).putString(cvsData, 'data_url');
+
+						if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
+							mkm.dataObj.xTrain.push(featureVec);
+							if (CURRTRIAL.test_scenebag_labels[0][0] == 0) {
+								mkm.dataObj.yTrain.push([0]);
+								// for SVM
+								// mkm.dataObj.yTrain.push([-1])
+							} else if (CURRTRIAL.test_scenebag_labels[0][0] == 1) {
+								mkm.dataObj.yTrain.push([1]);
+							}
+						} else {
+							mkm.dataObj.xTest = featureVec;
+							mkm.dataObj.yTest = CURRTRIAL.test_scenebag_labels[0][0];
+						}
+
+						if (CURRTRIAL.num == TASK.ModelConfig.trainIdx) {
+							let xTrain = tf.data.array(mkm.dataObj.xTrain);
+							let yTrain = tf.data.array(mkm.dataObj.yTrain);
+							let trainDataset = tf.data.zip({ xs: xTrain, ys: yTrain })
+								.batch(4)
+								.shuffle(4);
+
+							
+						}
+
+						// mkm.cvs SANITY CHECK HERE
+						// let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
+						// let cvsData = mkm.cvs.toDataURL();
+						// let path = (
+						// 	`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_test.png`
+						// );
+						// mkmodelsRef.child(path).putString(cvsData, 'data_url');
 						mkm.hasTestFeatures = true;							
 					} else if (taskscreen == 'Choice' && mkm.hasSampleFeatures && mkm.hasTestFeatures) {
 						mkm.hasSampleFeatures = false;

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -145,8 +145,8 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						// ctx2.stroke();
 						
 						ctx.drawImage(VISIBLECANVAS, mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight, 0, 0, 224, 224);
-						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs));
-						featureVec = featureVec.reshape([2048]);
+						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs), mkm.outputNode);
+						featureVec = featureVec.reshape(mkm.inputShape);
 
 						if (CURRTRIAL.num < TASK.ModelConfig.trainIdx) {
 							let oneHotIdx = mkm.getOneHotIdx(CURRTRIAL.sample_scenebag_label[0][0]);
@@ -206,8 +206,8 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						// ctx2.stroke();
 						
 						ctx.drawImage(VISIBLECANVAS, mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight, 0, 0, 224, 224);
-						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs));
-						featureVec = featureVec.reshape([2048]);
+						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs), mkm.ouputNode);
+						featureVec = featureVec.reshape(mkm.inputShape);
 
 						if (CURRTRIAL.num < TASK.ModelConfig.trainIdx) {
 							let oneHotIdx = mkm.getOneHotIdx(CURRTRIAL.test_scenebag_labels[0][0]);
@@ -271,7 +271,10 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						// ctx2.stroke();
 						
 						ctx.drawImage(VISIBLECANVAS, mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight, 0, 0, 224, 224);
-						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs));
+						// console.log(mkm.featureExtractor);
+						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs), mkm.ouputNode);
+						// console.log('featureVec:', featureVec);
+
 						featureVec = featureVec.reshape(mkm.inputShape);
 						if (CURRTRIAL.num < TASK.ModelConfig.trainIdx) {
 							console.log('CURRTRIAL.num:', CURRTRIAL.num);
@@ -279,15 +282,6 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 							let oneHotIdx = mkm.getOneHotIdx(CURRTRIAL.correctitem);
 							mkm.dataObj.yTrainLabels.push(oneHotIdx);
 							mkm.dataObj.yTrain.push(mkm.oneHotArr[oneHotIdx]);
-							// if (CURRTRIAL.correctitem == 0) {
-							// 	mkm.dataObj.yTrainLabels.push(0);
-							// 	mkm.dataObj.yTrain.push([1, 0]);
-							// 	// for SVM
-							// 	// mkm.dataObj.yTrain.push([-1])
-							// } else if (CURRTRIAL.correctitem == 1) {
-							// 	mkm.dataObj.yTrainLabels.push(1);
-							// 	mkm.dataObj.yTrain.push([0, 1]);
-							// }
 						} else {
 							let oneHotIdx = mkm.getOneHotIdx(CURRTRIAL.correctitem);
 							mkm.dataObj.xTest.push(featureVec);

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -150,15 +150,15 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
 							mkm.dataObj.xTrain.push(featureVec);
 							if (CURRTRIAL.sample_scenebag_label[0][0] == 0) {
-								mkm.dataObj.yTrain.push([0]);
+								mkm.dataObj.yTrain.push([1, 0]);
 								// for SVM
 								// mkm.dataObj.yTrain.push([-1])
 							} else if (CURRTRIAL.sample_scenebag_label[0][0] == 1) {
-								mkm.dataObj.yTrain.push([1]);
+								mkm.dataObj.yTrain.push([0, 1]);
 							}
 						} else {
-							mkm.dataObj.xTest = featureVec;
-							mkm.dataObj.yTest = CURRTRIAL.sample_scenebag_label[0][0];
+							mkm.dataObj.xTest.push(featureVec);
+							mkm.dataObj.yTest.push(CURRTRIAL.sample_scenebag_label[0][0]);
 						}
 						// mkm.cvs SANITY CHECK CODE
 						// let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
@@ -193,29 +193,21 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						// ctx2.stroke();
 						
 						ctx.drawImage(VISIBLECANVAS, mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight, 0, 0, 224, 224);
+						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs));
+						featureVec = featureVec.reshape([2048]);
 
 						if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
 							mkm.dataObj.xTrain.push(featureVec);
 							if (CURRTRIAL.test_scenebag_labels[0][0] == 0) {
-								mkm.dataObj.yTrain.push([0]);
+								mkm.dataObj.yTrain.push([1, 0]);
 								// for SVM
 								// mkm.dataObj.yTrain.push([-1])
 							} else if (CURRTRIAL.test_scenebag_labels[0][0] == 1) {
-								mkm.dataObj.yTrain.push([1]);
+								mkm.dataObj.yTrain.push([0, 1]);
 							}
 						} else {
-							mkm.dataObj.xTest = featureVec;
-							mkm.dataObj.yTest = CURRTRIAL.test_scenebag_labels[0][0];
-						}
-
-						if (CURRTRIAL.num == TASK.ModelConfig.trainIdx) {
-							let xTrain = tf.data.array(mkm.dataObj.xTrain);
-							let yTrain = tf.data.array(mkm.dataObj.yTrain);
-							let trainDataset = tf.data.zip({ xs: xTrain, ys: yTrain })
-								.batch(4)
-								.shuffle(4);
-
-							
+							mkm.dataObj.xTest.push(featureVec);
+							mkm.dataObj.yTest.push(CURRTRIAL.test_scenebag_labels[0][0]);
 						}
 
 						// mkm.cvs SANITY CHECK HERE
@@ -256,12 +248,28 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						// ctx2.stroke();
 						
 						ctx.drawImage(VISIBLECANVAS, mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight, 0, 0, 224, 224);
-						let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
-						let cvsData = mkm.cvs.toDataURL();
-						let path = (
-							`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
-						);
-						mkmodelsRef.child(path).putString(cvsData, 'data_url');
+						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs));
+						featureVec = featureVec.reshape([2048]);
+						if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
+							mkm.dataObj.xTrain.push(featureVec);
+							if (CURRTRIAL.correctitem == 0) {
+								mkm.dataObj.yTrain.push([1, 0]);
+								// for SVM
+								// mkm.dataObj.yTrain.push([-1])
+							} else if (CURRTRIAL.correctitem == 1) {
+								mkm.dataObj.yTrain.push([0, 1]);
+							}
+						} else {
+							mkm.dataObj.xTest.push(featureVec);
+							mkm.dataObj.yTest.push(CURRTRIAL.sample_scenebag_label[0][0]);
+						}
+						// mkm.cvs SANITY CHECK CODE
+						// let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
+						// let cvsData = mkm.cvs.toDataURL();
+						// let path = (
+						// 	`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
+						// );
+						// mkmodelsRef.child(path).putString(cvsData, 'data_url');
 						mkm.hasSampleFeatures = true;
 					} else if (taskscreen != 'Sample' && mkm.hasSampleFeatures) {
 						mkm.hasSampleFeatures = false;

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -118,43 +118,76 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 
 			// MkModel Logic
 			
-			if (TASK.SameDifferent > 0 && lenArgs == 7) {
+			// if (TASK.SameDifferent > 0 && lenArgs == 7) {
+			if (lenArgs == 7 && mkm != undefined) {
 				console.log('displayTrial SD');
+				console.log('taskscreen:', taskscreen);
 				if (taskscreen == 'Sample' && !mkm.hasSampleFeatures) {
 					let ctx = mkm.cvs.getContext('2d');
 					ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
 					let label = CURRTRIAL.sample_scenebag_label[0][0];
-					let sxOffset = (
-						IMAGES.Sample[label].IMAGES.sizeInches
-						* ENV.PhysicalPPI
-						/ ENV.ScreenRatio
-					);
-					let sx = (
-						boundingBoxesChoice3D.x[0][1]
-						+ boundingBoxesChoice3D.x[0][0]
-						- sxOffset
-					);
-					let syOffset = (
-						IMAGES.Sample[label].IMAGES.sizeInches
-						* ENV.PhysicalPPI
-						/ ENV.ScreenRatio
-					);
-					let sy = (
-						(boundingBoxesChoice3D.y[0][1] + boundingBoxesChoice3D.y[0][0] - syOffset)
-						/ ENV.ScreenRatio
+					let idx = CURRTRIAL.sample_scenebag_index[0][0];
+					let obj = IMAGES.Sample[label].OBJECTS;
+
+					let sx, sy, sxOffset, syOffset, sWidth, sHeight;
+
+					if (IMAGES.Sample[label].IMAGES.imageidx.length > 0 && IMAGES.Sample[label].IMAGES.imagebag) { // IF background image
+						sx = boundingBoxesChoice3D.x[0][0] * ENV.ScreenRatio;
+						sy = (boundingBoxesChoice3D.y[0][0] - CANVAS.offsettop) * ENV.ScreenRatio;
+						sWidth = Math.round(
+							IMAGES.Sample[label].IMAGES.sizeInches
+							* ENV.ViewportPPI
+							* ENV.ScreenRatio
+						);
+						sHeight = sWidth;
+					} else {
+						console.log('hello');
+						try {
+							sxOffset = (
+								obj[Object.keys(obj)[0]].sizeInches[idx] * ENV.ViewportPPI
+							);
+							syOffset = sxOffset;
+						} catch {
+							sxOffset = (
+								obj[Object.keys(obj)[0]].sizeInches * ENV.ViewportPPI
+							);
+							syOffset = sxOffset;
+						}
+
+						sx = (
+							boundingBoxesChoice3D.x[0][0]
+							+ boundingBoxesChoice3D.x[0][1]
+							- sxOffset
+						);
 						
-					);
-					let sHeight = Math.round(
-						IMAGES.Sample[label].IMAGES.sizeInches
-						* ENV.PhysicalPPI
-					);
-					let sWidth = sHeight;
-					console.log(`SAMPLE sx=${sx}; sy=${sy}; sWidth=${sWidth}; sHeight=${sHeight}; syOffset=${syOffset}`);
+						sy = (
+							(boundingBoxesChoice3D.y[0][0] - CANVAS.offsettop)
+							+ (boundingBoxesChoice3D.y[0][1] - CANVAS.offsettop)
+							- syOffset
+						);
+						sHeight = sxOffset * ENV.ScreenRatio;
+						sWidth = sHeight;
+					}
+					// let sx = (
+					// 	boundingBoxesChoice3D.x[0][0]
+					// 	* ENV.ScreenRatio
+					// );
+					// let sy = (
+					// 	(boundingBoxesChoice3D.y[0][0] - CANVAS.offsettop)
+					// 	* ENV.ScreenRatio
+					// );
+					// let sHeight = Math.round(
+					// 	IMAGES.Sample[label].IMAGES.sizeInches
+					// 	* ENV.ViewportPPI
+					// 	* ENV.ScreenRatio
+					// );
+					// let sWidth = sHeight;
+					console.log(`SAMPLE sx=${sx}; sy=${sy}; sWidth=${sWidth}; sHeight=${sHeight}`);
 					console.log('boundingBoxesChoice3D:', boundingBoxesChoice3D);
 					let visiblecvs = document.getElementById("canvaseyetracker");
 					let ctx2 = visiblecvs.getContext('2d');
 				
-					ctx2.rect(772, 674, sWidth, sHeight);
+					ctx2.rect(sx, sy, sWidth, sHeight);
 					ctx2.stroke();
 					
 					ctx.drawImage(VISIBLECANVAS, sx, sy, sWidth, sHeight, 0, 0, 224, 224);
@@ -169,37 +202,21 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 					let ctx = mkm.cvs.getContext('2d');
 					ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
 					let label = CURRTRIAL.test_scenebag_labels[0][0];
-					let sxOffset = (
-						IMAGES.Test[label].IMAGES.sizeInches
-						* ENV.PhysicalPPI
-						/ ENV.ScreenRatio
-					);
 					let sx = (
-						boundingBoxesChoice3D.x[0][1]
-						+ boundingBoxesChoice3D.x[0][0]
-						- sxOffset
-					);
-					let syOffset = (
-						IMAGES.Test[label].IMAGES.sizeInches
-						* ENV.PhysicalPPI
-						/ ENV.ScreenRatio
+						boundingBoxesChoice3D.x[0][0]
+						* ENV.ScreenRatio
 					);
 					let sy = (
-						(boundingBoxesChoice3D.y[0][1] + boundingBoxesChoice3D.y[0][0] - syOffset)
-						/ ENV.ScreenRatio
-						
+						(boundingBoxesChoice3D.y[0][0] - CANVAS.offsettop)
+						* ENV.ScreenRatio
 					);
 					let sHeight = Math.round(
 						IMAGES.Test[label].IMAGES.sizeInches
-						* ENV.PhysicalPPI
+						* ENV.ViewportPPI
+						* ENV.ScreenRatio
 					);
-					// let sHeight = 300;
 					let sWidth = sHeight;
 					console.log(`TEST sx=${sx}; sy=${sy}; sWidth=${sWidth}; sHeight=${sHeight}`);
-					console.log('boundingBoxesChoice3D:', boundingBoxesChoice3D);
-
-
-					console.log(`mkm.cvs.width=${mkm.cvs.width}; mkm.cvs.height=${mkm.cvs.height}`);
 					ctx.drawImage(VISIBLECANVAS, sx, sy, sWidth, sHeight, 0, 0, 224, 224);
 					let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
 					let cvsData = mkm.cvs.toDataURL();
@@ -304,19 +321,21 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 }//FUNCTION displayTrial
 
 
-function render3D(taskscreen,s,f,gr,fr,sc,ob,id){
-	f = frame.frames[frame.current][s]
+function render3D(taskscreen, s, f, gr, fr, sc, ob, id) {
+	f = frame.frames[frame.current][s];
 	//var taskscreen = sc[f].charAt(0).toUpperCase() + sc[f].slice(1)
 
-	renderer.autoClear = false
-	for (var j = 0; j<=ob[f].length - 1; j++){
-		renderer.clear()
+	renderer.autoClear = false;
+	for (var j = 0; j < ob[f].length; j++) {
+		renderer.clear();
 		
-		var boundingBox = updateSingleFrame3D(taskscreen,
-											ob[f][j],
-											id[f][j],
-											fr[f],
-											gr[f][j])
+		var boundingBox = updateSingleFrame3D(
+			taskscreen,
+			ob[f][j],
+			id[f][j],
+			fr[f],
+			gr[f][j]
+		);
 		
 		if (s==0 && typeof(boundingBox) != "undefined" && typeof(boundingBox[ob[f][j]]) != "undefined" && typeof(boundingBox[ob[f][j]][0]) != "undefined"){
 			boundingBoxesChoice3JS.x[j] = boundingBox[ob[f][j]][0].x
@@ -352,19 +371,20 @@ function render3D(taskscreen,s,f,gr,fr,sc,ob,id){
 			fr[f],
 			gr[f][j])
 			
-	    OFFSCREENCANVAS.getContext('2d').filter = objFilterSingleFrame
-		OFFSCREENCANVAS.getContext('2d').drawImage(renderer.domElement,0,0,OFFSCREENCANVAS.width,OFFSCREENCANVAS.height)	
-		OFFSCREENCANVAS.getContext('2d').filter = 'none'
+	  OFFSCREENCANVAS.getContext('2d').filter = objFilterSingleFrame;
+		OFFSCREENCANVAS.getContext('2d').drawImage(renderer.domElement,0,0,OFFSCREENCANVAS.width,OFFSCREENCANVAS.height);
+		OFFSCREENCANVAS.getContext('2d').filter = 'none';
 	}//FOR j display items
 }//FUNCTION render3D
 
 async function render2D(taskscreen,s,f,gr,fr,sc,ob,id,canvasobj){
-	if (FLAGS.savedata == 0 && s==0 && FLAGS.underlayGridPoints == 1){
+	if (FLAGS.savedata == 0 && s==0 && FLAGS.underlayGridPoints == 1) {
 		renderBlankWithGridMarkers(
 			ENV.XGridCenter,ENV.YGridCenter, 
 			CURRTRIAL.FixationGridIndex,CURRTRIAL.samplegridindex,TASK.TestGridIndex, TASK.ChoiceGridIndex,
 			ENV.FixationRadius,ENV.ChoiceRadius,
-			ENV.CanvasRatio,canvasobj);
+			ENV.CanvasRatio,canvasobj
+		);
 	}//IF !savedata, underlay grid
 	
 	if (f==0  || taskscreen != sc[f-1] || id[f] != id[f-1] || fr[f] != fr[f-1]){
@@ -432,6 +452,7 @@ function renderImage2D(im,sc,ob,id,fr,gr,imgFilterSingleFrame,canvasobj){
 	xbound[1]=xbound[1]+CANVAS.offsetleft;
 	ybound[0]=ybound[0]+CANVAS.offsettop;
 	ybound[1]=ybound[1]+CANVAS.offsettop;
+	console.log('xbound:', xbound, 'ybound:', ybound);
 
 	return [xbound, ybound]
 }//FUNCTION renderImage2D

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -101,133 +101,131 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 //------------------- Frame is fully on display ---------------------//
 			//----- (1) Merge Bounding Boxes
 			if (updated2d){
-				console.log('updated2d');
 				boundingBoxesChoice3D.x = boundingBoxesChoice2D.x
 				boundingBoxesChoice3D.y = boundingBoxesChoice2D.y
 			}//
 			if (updated3d){
-				console.log('updated3d');
 				boundingBoxesChoice3D.x = boundingBoxesChoice3JS.x
 				boundingBoxesChoice3D.y = boundingBoxesChoice3JS.y			
 			}
 
 			// console.log(`taskscreen: ${taskscreen}; taskscreen0: ${taskscreen0}; boundingBoxesChoice3D: ${JSON.stringify(boundingBoxesChoice3D)}`);
-			if (taskscreen == 'Sample') {
-				console.log(`arguments.length=${lenArgs}`);
-			}
+			// if (taskscreen == 'Sample') {
+			// 	console.log(`arguments.length=${lenArgs}`);
+			// }
 
 			// MkModel Logic
 			
 			// if (TASK.SameDifferent > 0 && lenArgs == 7) {
-			if (lenArgs == 7 && mkm != undefined) {
-				console.log('displayTrial SD');
-				console.log('taskscreen:', taskscreen);
-				if (taskscreen == 'Sample' && !mkm.hasSampleFeatures) {
-					let ctx = mkm.cvs.getContext('2d');
-					ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
-					let label = CURRTRIAL.sample_scenebag_label[0][0];
-					let idx = CURRTRIAL.sample_scenebag_index[0][0];
-					let obj = IMAGES.Sample[label].OBJECTS;
+			if (lenArgs == 7 && mkm) {
+				if (TASK.SameDifferent > 0) {
+					if (taskscreen == 'Sample' && !mkm.hasSampleFeatures) {
+						let ctx = mkm.cvs.getContext('2d');
+						ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
+						let label = CURRTRIAL.sample_scenebag_label[0][0];
+						let params = {
+							image: IMAGES.Sample[label].IMAGES,
+							object: IMAGES.Sample[label].OBJECTS,
+							idx: CURRTRIAL.sample_scenebag_index[0][0],
+							ViewportPPI: ENV.ViewportPPI,
+							ScreenRatio: ENV.ScreenRatio,
+							offsettop: CANVAS.offsettop,
+							boundingBoxes3D: boundingBoxesChoice3D,
+							boundingBoxes2D: boundingBoxesChoice2D
+						};
+	
+						let mkmBoundingBox = mkm.getMkModelBoundingBox(params);
 
-					let sx, sy, sxOffset, syOffset, sWidth, sHeight;
-
-					if (IMAGES.Sample[label].IMAGES.imageidx.length > 0 && IMAGES.Sample[label].IMAGES.imagebag) { // IF background image
-						sx = boundingBoxesChoice3D.x[0][0] * ENV.ScreenRatio;
-						sy = (boundingBoxesChoice3D.y[0][0] - CANVAS.offsettop) * ENV.ScreenRatio;
-						sWidth = Math.round(
-							IMAGES.Sample[label].IMAGES.sizeInches
-							* ENV.ViewportPPI
-							* ENV.ScreenRatio
-						);
-						sHeight = sWidth;
-					} else {
-						console.log('hello');
-						try {
-							sxOffset = (
-								obj[Object.keys(obj)[0]].sizeInches[idx] * ENV.ViewportPPI
-							);
-							syOffset = sxOffset;
-						} catch {
-							sxOffset = (
-								obj[Object.keys(obj)[0]].sizeInches * ENV.ViewportPPI
-							);
-							syOffset = sxOffset;
-						}
-
-						sx = (
-							boundingBoxesChoice3D.x[0][0]
-							+ boundingBoxesChoice3D.x[0][1]
-							- sxOffset
-						);
+						// mkmBoundingBox SANITY CHECK CODE
+						// console.log(`SAMPLE sx=${mkmBoundingBox.sx}; sy=${mkmBoundingBox.sy}; sWidth=${mkmBoundingBox.sWidth}; sHeight=${mkmBoundingBox.sHeight}`);
+						// let visiblecvs = document.getElementById("canvaseyetracker");
+						// let ctx2 = visiblecvs.getContext('2d');
+						// ctx2.rect(mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight);
+						// ctx2.stroke();
 						
-						sy = (
-							(boundingBoxesChoice3D.y[0][0] - CANVAS.offsettop)
-							+ (boundingBoxesChoice3D.y[0][1] - CANVAS.offsettop)
-							- syOffset
+						ctx.drawImage(VISIBLECANVAS, mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight, 0, 0, 224, 224);
+						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs));
+						featureVec = featureVec.reshape([2048]);
+						// mkm.cvs SANITY CHECK CODE
+						// let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
+						// let cvsData = mkm.cvs.toDataURL();
+						// let path = (
+						// 	`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
+						// );
+						// mkmodelsRef.child(path).putString(cvsData, 'data_url');
+						mkm.hasSampleFeatures = true;							
+					} else if (taskscreen == 'Test' && !mkm.hasTestFeatures) {
+						let ctx = mkm.cvs.getContext('2d');
+						ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
+						let label = CURRTRIAL.test_scenebag_labels[0][0];
+						let params = {
+							image: IMAGES.Test[label].IMAGES,
+							object: IMAGES.Test[label].OBJECTS,
+							idx: CURRTRIAL.test_scenebag_indices[0][0],
+							ViewportPPI: ENV.ViewportPPI,
+							ScreenRatio: ENV.ScreenRatio,
+							offsettop: CANVAS.offsettop,
+							boundingBoxes3D: boundingBoxesChoice3D,
+							boundingBoxes2D: boundingBoxesChoice2D
+						};
+	
+						let mkmBoundingBox = mkm.getMkModelBoundingBox(params);
+
+						// mkmBoundingBox SANITY CHECK CODE
+						// console.log(`TEST sx=${mkmBoundingBox.sx}; sy=${mkmBoundingBox.sy}; sWidth=${mkmBoundingBox.sWidth}; sHeight=${mkmBoundingBox.sHeight}`);
+						// let visiblecvs = document.getElementById("canvaseyetracker");
+						// let ctx2 = visiblecvs.getContext('2d');
+						// ctx2.rect(mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight);
+						// ctx2.stroke();
+						
+						ctx.drawImage(VISIBLECANVAS, mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight, 0, 0, 224, 224);
+						let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
+						let cvsData = mkm.cvs.toDataURL();
+						let path = (
+							`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_test.png`
 						);
-						sHeight = sxOffset * ENV.ScreenRatio;
-						sWidth = sHeight;
+						mkmodelsRef.child(path).putString(cvsData, 'data_url');
+						mkm.hasTestFeatures = true;							
+					} else if (taskscreen == 'Choice' && mkm.hasSampleFeatures && mkm.hasTestFeatures) {
+						mkm.hasSampleFeatures = false;
+						mkm.hasTestFeatures = false;	
 					}
-					// let sx = (
-					// 	boundingBoxesChoice3D.x[0][0]
-					// 	* ENV.ScreenRatio
-					// );
-					// let sy = (
-					// 	(boundingBoxesChoice3D.y[0][0] - CANVAS.offsettop)
-					// 	* ENV.ScreenRatio
-					// );
-					// let sHeight = Math.round(
-					// 	IMAGES.Sample[label].IMAGES.sizeInches
-					// 	* ENV.ViewportPPI
-					// 	* ENV.ScreenRatio
-					// );
-					// let sWidth = sHeight;
-					console.log(`SAMPLE sx=${sx}; sy=${sy}; sWidth=${sWidth}; sHeight=${sHeight}`);
-					console.log('boundingBoxesChoice3D:', boundingBoxesChoice3D);
-					let visiblecvs = document.getElementById("canvaseyetracker");
-					let ctx2 = visiblecvs.getContext('2d');
-				
-					ctx2.rect(sx, sy, sWidth, sHeight);
-					ctx2.stroke();
-					
-					ctx.drawImage(VISIBLECANVAS, sx, sy, sWidth, sHeight, 0, 0, 224, 224);
-					let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
-					let cvsData = mkm.cvs.toDataURL();
-					let path = (
-						`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
-					);
-					mkmodelsRef.child(path).putString(cvsData, 'data_url');
-					mkm.hasSampleFeatures = true;
-				} else if (taskscreen == 'Test' && !mkm.hasTestFeatures) {
-					let ctx = mkm.cvs.getContext('2d');
-					ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
-					let label = CURRTRIAL.test_scenebag_labels[0][0];
-					let sx = (
-						boundingBoxesChoice3D.x[0][0]
-						* ENV.ScreenRatio
-					);
-					let sy = (
-						(boundingBoxesChoice3D.y[0][0] - CANVAS.offsettop)
-						* ENV.ScreenRatio
-					);
-					let sHeight = Math.round(
-						IMAGES.Test[label].IMAGES.sizeInches
-						* ENV.ViewportPPI
-						* ENV.ScreenRatio
-					);
-					let sWidth = sHeight;
-					console.log(`TEST sx=${sx}; sy=${sy}; sWidth=${sWidth}; sHeight=${sHeight}`);
-					ctx.drawImage(VISIBLECANVAS, sx, sy, sWidth, sHeight, 0, 0, 224, 224);
-					let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
-					let cvsData = mkm.cvs.toDataURL();
-					let path = (
-						`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_test.png`
-					);
-					mkmodelsRef.child(path).putString(cvsData, 'data_url');
-					mkm.hasTestFeatures = true;
-				} else if (taskscreen == 'Choice' && mkm.hasSampleFeatures && mkm.hasTestFeatures) {
-					mkm.hasSampleFeatures = false;
-					mkm.hasTestFeatures = false;
+				} else {
+					if (taskscreen == 'Sample' && !mkm.hasSampleFeatures) {
+						let ctx = mkm.cvs.getContext('2d');
+						ctx.clearRect(0, 0, mkm.cvs.width, mkm.cvs.height);
+						let label = CURRTRIAL.sample_scenebag_label[0][0];
+						let params = {
+							image: IMAGES.Sample[label].IMAGES,
+							object: IMAGES.Sample[label].OBJECTS,
+							idx: CURRTRIAL.sample_scenebag_index[0][0],
+							ViewportPPI: ENV.ViewportPPI,
+							ScreenRatio: ENV.ScreenRatio,
+							offsettop: CANVAS.offsettop,
+							boundingBoxes3D: boundingBoxesChoice3D,
+							boundingBoxes2D: boundingBoxesChoice2D
+						};
+	
+						let mkmBoundingBox = mkm.getMkModelBoundingBox(params);
+
+						// mkmBoundingBox SANITY CHECK CODE
+						// console.log(`SAMPLE sx=${mkmBoundingBox.sx}; sy=${mkmBoundingBox.sy}; sWidth=${mkmBoundingBox.sWidth}; sHeight=${mkmBoundingBox.sHeight}`);
+						// let visiblecvs = document.getElementById("canvaseyetracker");
+						// let ctx2 = visiblecvs.getContext('2d');
+						// ctx2.rect(mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight);
+						// ctx2.stroke();
+						
+						ctx.drawImage(VISIBLECANVAS, mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight, 0, 0, 224, 224);
+						let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
+						let cvsData = mkm.cvs.toDataURL();
+						let path = (
+							`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
+						);
+						mkmodelsRef.child(path).putString(cvsData, 'data_url');
+						mkm.hasSampleFeatures = true;
+					} else if (taskscreen != 'Sample' && mkm.hasSampleFeatures) {
+						mkm.hasSampleFeatures = false;
+					}
 				}
 
 			}
@@ -437,8 +435,6 @@ function renderImage2D(im,sc,ob,id,fr,gr,imgFilterSingleFrame,canvasobj){
 	var ybound=[];
 	xleft = Math.round(ENV.XGridCenter[gr]/ENV.CanvasRatio - 0.5*wdpixels);
 	ytop = Math.round(ENV.YGridCenter[gr]/ENV.CanvasRatio - 0.5*htpixels);
-
-	console.log(`xleft=${xleft}, ytop=${ytop}, wdpixels=${wdpixels}, htpixels=${htpixels}`);
 			
 	context.filter = imgFilterSingleFrame
 	context.drawImage(im,xleft,ytop,wdpixels,htpixels);
@@ -452,7 +448,6 @@ function renderImage2D(im,sc,ob,id,fr,gr,imgFilterSingleFrame,canvasobj){
 	xbound[1]=xbound[1]+CANVAS.offsetleft;
 	ybound[0]=ybound[0]+CANVAS.offsettop;
 	ybound[1]=ybound[1]+CANVAS.offsettop;
-	console.log('xbound:', xbound, 'ybound:', ybound);
 
 	return [xbound, ybound]
 }//FUNCTION renderImage2D

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -1,5 +1,9 @@
 //================== IMAGE RENDERING ==================//
 function displayTrial(ti,gr,fr,sc,ob,id){
+	console.log('arguments.length:', arguments.length);
+	if (arguments.length == 7) {
+		console.log('mkm:', mkm);
+	}
 // ti = time, gr = grid, fr = frame
 // sc = screen, ob = object label, id = index of renderparam
 	var resolveFunc
@@ -13,13 +17,14 @@ function displayTrial(ti,gr,fr,sc,ob,id){
 		resolveFunc = resolve;
 		errFunc = reject;
 	}).then();
-
 	var start = null;
 	CURRTRIAL.tsequenceactual = []
 	async function updateCanvas(timestamp){
+		
 		if (!start) start = timestamp; //IF start has not been set to a float timestamp, set it now.
 
 		if (timestamp - start > ti[frame.current]){
+			console.log('updateCanvas called');
 			//----- RENDER ALL ELEMENTS
 			if (!ENV.OffscreenCanvasAvailable){
 					renderShape2D('Blank',[-1],OFFSCREENCANVAS)				
@@ -28,6 +33,8 @@ function displayTrial(ti,gr,fr,sc,ob,id){
 			for (var s = 0; s<=frame.frames[frame.current].length-1; s++){
 				f = frame.frames[frame.current][s]
 				var taskscreen = sc[f].charAt(0).toUpperCase() + sc[f].slice(1)
+				console.log('taskscreen:', taskscreen);
+				
 				if (s==0){
 					var taskscreen0 = taskscreen
 				}//IF primary screen

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -140,6 +140,7 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						// console.log(`SAMPLE sx=${mkmBoundingBox.sx}; sy=${mkmBoundingBox.sy}; sWidth=${mkmBoundingBox.sWidth}; sHeight=${mkmBoundingBox.sHeight}`);
 						// let visiblecvs = document.getElementById("canvaseyetracker");
 						// let ctx2 = visiblecvs.getContext('2d');
+						// ctx2.clearRect(0, 0, EYETRACKERCANVAS.width, EYETRACKERCANVAS.height);
 						// ctx2.rect(mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight);
 						// ctx2.stroke();
 						
@@ -167,6 +168,7 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						// 	`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
 						// );
 						// mkmodelsRef.child(path).putString(cvsData, 'data_url');
+						// ctx2.clearRect(0, 0, EYETRACKERCANVAS.width, EYETRACKERCANVAS.height);
 						mkm.hasSampleFeatures = true;							
 					} else if (taskscreen == 'Test' && !mkm.hasTestFeatures) {
 						let ctx = mkm.cvs.getContext('2d');
@@ -189,6 +191,7 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						// console.log(`TEST sx=${mkmBoundingBox.sx}; sy=${mkmBoundingBox.sy}; sWidth=${mkmBoundingBox.sWidth}; sHeight=${mkmBoundingBox.sHeight}`);
 						// let visiblecvs = document.getElementById("canvaseyetracker");
 						// let ctx2 = visiblecvs.getContext('2d');
+						// ctx2.clearRect(0, 0, EYETRACKERCANVAS.width, EYETRACKERCANVAS.height);
 						// ctx2.rect(mkmBoundingBox.sx, mkmBoundingBox.sy, mkmBoundingBox.sWidth, mkmBoundingBox.sHeight);
 						// ctx2.stroke();
 						
@@ -217,6 +220,7 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						// 	`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_test.png`
 						// );
 						// mkmodelsRef.child(path).putString(cvsData, 'data_url');
+						// ctx2.clearRect(0, 0, EYETRACKERCANVAS.width, EYETRACKERCANVAS.height);
 						mkm.hasTestFeatures = true;							
 					} else if (taskscreen == 'Choice' && mkm.hasSampleFeatures && mkm.hasTestFeatures) {
 						mkm.hasSampleFeatures = false;
@@ -270,6 +274,7 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						// 	`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
 						// );
 						// mkmodelsRef.child(path).putString(cvsData, 'data_url');
+						ctx2.clearRect(0, 0, EYETRACKERCANVAS.width, EYETRACKERCANVAS.height);
 						mkm.hasSampleFeatures = true;
 					} else if (taskscreen != 'Sample' && mkm.hasSampleFeatures) {
 						mkm.hasSampleFeatures = false;

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -152,11 +152,13 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 							mkm.dataObj.xTrain.push(featureVec);
 							if (CURRTRIAL.sample_scenebag_label[0][0] == 0) {
 								mkm.dataObj.yTrainLabels.push(0);
+								// mkm.dataObj.yTrain.push([0]);
 								mkm.dataObj.yTrain.push([1, 0]);
 								// for SVM
 								// mkm.dataObj.yTrain.push([-1])
 							} else if (CURRTRIAL.sample_scenebag_label[0][0] == 1) {
 								mkm.dataObj.yTrainLabels.push(1);
+								// mkm.dataObj.yTrain.push([1]);
 								mkm.dataObj.yTrain.push([0, 1]);
 							}
 						} else {
@@ -205,11 +207,13 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 							mkm.dataObj.xTrain.push(featureVec);
 							if (CURRTRIAL.test_scenebag_labels[0][0] == 0) {
 								mkm.dataObj.yTrainLabels.push(0);
+								// mkm.dataObj.yTrain.push([0]);
 								mkm.dataObj.yTrain.push([1, 0]);
 								// for SVM
 								// mkm.dataObj.yTrain.push([-1])
 							} else if (CURRTRIAL.test_scenebag_labels[0][0] == 1) {
 								mkm.dataObj.yTrainLabels.push(1);
+								// mkm.dataObj.yTrain.push([1]);
 								mkm.dataObj.yTrain.push([0, 1]);
 							}
 						} else {
@@ -261,10 +265,12 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
 							mkm.dataObj.xTrain.push(featureVec);
 							if (CURRTRIAL.correctitem == 0) {
+								mkm.dataObj.yTrainLabels.push(0);
 								mkm.dataObj.yTrain.push([1, 0]);
 								// for SVM
 								// mkm.dataObj.yTrain.push([-1])
 							} else if (CURRTRIAL.correctitem == 1) {
+								mkm.dataObj.yTrainLabels.push(1);
 								mkm.dataObj.yTrain.push([0, 1]);
 							}
 						} else {
@@ -272,13 +278,13 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 							mkm.dataObj.yTest.push(CURRTRIAL.sample_scenebag_label[0][0]);
 						}
 						// mkm.cvs SANITY CHECK CODE
-						// let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
-						// let cvsData = mkm.cvs.toDataURL();
-						// let path = (
-						// 	`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
-						// );
-						// mkmodelsRef.child(path).putString(cvsData, 'data_url');
-						ctx2.clearRect(0, 0, EYETRACKERCANVAS.width, EYETRACKERCANVAS.height);
+						let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
+						let cvsData = mkm.cvs.toDataURL();
+						let path = (
+							`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
+						);
+						mkmodelsRef.child(path).putString(cvsData, 'data_url');
+						// ctx2.clearRect(0, 0, EYETRACKERCANVAS.width, EYETRACKERCANVAS.height);
 						mkm.hasSampleFeatures = true;
 					} else if (taskscreen != 'Sample' && mkm.hasSampleFeatures) {
 						mkm.hasSampleFeatures = false;

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -148,22 +148,28 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs));
 						featureVec = featureVec.reshape([2048]);
 
-						if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
+						if (CURRTRIAL.num < TASK.ModelConfig.trainIdx) {
+							let oneHotIdx = mkm.getOneHotIdx(CURRTRIAL.sample_scenebag_label[0][0]);
+							mkm.dataObj.yTrainLabels.push(oneHotIdx);
+							mkm.dataObj.yTrain.push(mkm.oneHotArr[oneHotIdx]);
 							mkm.dataObj.xTrain.push(featureVec);
-							if (CURRTRIAL.sample_scenebag_label[0][0] == 0) {
-								mkm.dataObj.yTrainLabels.push(0);
-								// mkm.dataObj.yTrain.push([0]);
-								mkm.dataObj.yTrain.push([1, 0]);
-								// for SVM
-								// mkm.dataObj.yTrain.push([-1])
-							} else if (CURRTRIAL.sample_scenebag_label[0][0] == 1) {
-								mkm.dataObj.yTrainLabels.push(1);
-								// mkm.dataObj.yTrain.push([1]);
-								mkm.dataObj.yTrain.push([0, 1]);
-							}
+							
+							// if (CURRTRIAL.sample_scenebag_label[0][0] == 0) {
+							// 	mkm.dataObj.yTrainLabels.push(0);
+							// 	// mkm.dataObj.yTrain.push([0]);
+							// 	mkm.dataObj.yTrain.push([1, 0]);
+							// 	// for SVM
+							// 	// mkm.dataObj.yTrain.push([-1])
+							// } else if (CURRTRIAL.sample_scenebag_label[0][0] == 1) {
+							// 	mkm.dataObj.yTrainLabels.push(1);
+							// 	// mkm.dataObj.yTrain.push([1]);
+							// 	mkm.dataObj.yTrain.push([0, 1]);
+							// }
 						} else {
+							let oneHotIdx = mkm.getOneHotIdx(CURRTRIAL.sample_scenebag_label[0][0]);
 							mkm.dataObj.xTest.push(featureVec);
-							mkm.dataObj.yTest.push(CURRTRIAL.sample_scenebag_label[0][0]);
+							// mkm.dataObj.yTest.push(CURRTRIAL.sample_scenebag_label[0][0]);
+							mkm.dataObj.yTest.push(oneHotIdx);
 						}
 						// mkm.cvs SANITY CHECK CODE
 						let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
@@ -203,22 +209,27 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						let featureVec = mkm.featureExtractor.execute(mkm.normalizePixelValues(mkm.cvs));
 						featureVec = featureVec.reshape([2048]);
 
-						if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
+						if (CURRTRIAL.num < TASK.ModelConfig.trainIdx) {
+							let oneHotIdx = mkm.getOneHotIdx(CURRTRIAL.test_scenebag_labels[0][0]);
+							mkm.dataObj.yTrainLabels.push(oneHotIdx);
+							mkm.dataObj.yTrain.push(mkm.oneHotArr[oneHotIdx]);
 							mkm.dataObj.xTrain.push(featureVec);
-							if (CURRTRIAL.test_scenebag_labels[0][0] == 0) {
-								mkm.dataObj.yTrainLabels.push(0);
-								// mkm.dataObj.yTrain.push([0]);
-								mkm.dataObj.yTrain.push([1, 0]);
-								// for SVM
-								// mkm.dataObj.yTrain.push([-1])
-							} else if (CURRTRIAL.test_scenebag_labels[0][0] == 1) {
-								mkm.dataObj.yTrainLabels.push(1);
-								// mkm.dataObj.yTrain.push([1]);
-								mkm.dataObj.yTrain.push([0, 1]);
-							}
+							// if (CURRTRIAL.test_scenebag_labels[0][0] == 0) {
+							// 	mkm.dataObj.yTrainLabels.push(0);
+							// 	// mkm.dataObj.yTrain.push([0]);
+							// 	mkm.dataObj.yTrain.push([1, 0]);
+							// 	// for SVM
+							// 	// mkm.dataObj.yTrain.push([-1])
+							// } else if (CURRTRIAL.test_scenebag_labels[0][0] == 1) {
+							// 	mkm.dataObj.yTrainLabels.push(1);
+							// 	// mkm.dataObj.yTrain.push([1]);
+							// 	mkm.dataObj.yTrain.push([0, 1]);
+							// }
 						} else {
+							let oneHotIdx = mkm.getOneHotIdx(CURRTRIAL.test_scenebag_labels[0][0]);
 							mkm.dataObj.xTest.push(featureVec);
-							mkm.dataObj.yTest.push(CURRTRIAL.test_scenebag_labels[0][0]);
+							// mkm.dataObj.yTest.push(CURRTRIAL.test_scenebag_labels[0][0]);
+							mkm.dataObj.yTest.push(oneHotIdx);
 						}
 
 						// mkm.cvs SANITY CHECK HERE
@@ -265,18 +276,23 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						if (CURRTRIAL.num < TASK.ModelConfig.trainIdx) {
 							console.log('CURRTRIAL.num:', CURRTRIAL.num);
 							mkm.dataObj.xTrain.push(featureVec);
-							if (CURRTRIAL.correctitem == 0) {
-								mkm.dataObj.yTrainLabels.push(0);
-								mkm.dataObj.yTrain.push([1, 0]);
-								// for SVM
-								// mkm.dataObj.yTrain.push([-1])
-							} else if (CURRTRIAL.correctitem == 1) {
-								mkm.dataObj.yTrainLabels.push(1);
-								mkm.dataObj.yTrain.push([0, 1]);
-							}
+							let oneHotIdx = mkm.getOneHotIdx(CURRTRIAL.correctitem);
+							mkm.dataObj.yTrainLabels.push(oneHotIdx);
+							mkm.dataObj.yTrain.push(mkm.oneHotArr[oneHotIdx]);
+							// if (CURRTRIAL.correctitem == 0) {
+							// 	mkm.dataObj.yTrainLabels.push(0);
+							// 	mkm.dataObj.yTrain.push([1, 0]);
+							// 	// for SVM
+							// 	// mkm.dataObj.yTrain.push([-1])
+							// } else if (CURRTRIAL.correctitem == 1) {
+							// 	mkm.dataObj.yTrainLabels.push(1);
+							// 	mkm.dataObj.yTrain.push([0, 1]);
+							// }
 						} else {
+							let oneHotIdx = mkm.getOneHotIdx(CURRTRIAL.correctitem);
 							mkm.dataObj.xTest.push(featureVec);
-							mkm.dataObj.yTest.push(CURRTRIAL.sample_scenebag_label[0][0]);
+							// mkm.dataObj.yTest.push(CURRTRIAL.sample_scenebag_label[0][0]);
+							mkm.dataObj.yTest.push(oneHotIdx);
 						}
 						// mkm.cvs SANITY CHECK CODE
 						// let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');

--- a/public/mkturk/mkturk_screenfunctions.js
+++ b/public/mkturk/mkturk_screenfunctions.js
@@ -151,10 +151,12 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
 							mkm.dataObj.xTrain.push(featureVec);
 							if (CURRTRIAL.sample_scenebag_label[0][0] == 0) {
+								mkm.dataObj.yTrainLabels.push(0);
 								mkm.dataObj.yTrain.push([1, 0]);
 								// for SVM
 								// mkm.dataObj.yTrain.push([-1])
 							} else if (CURRTRIAL.sample_scenebag_label[0][0] == 1) {
+								mkm.dataObj.yTrainLabels.push(1);
 								mkm.dataObj.yTrain.push([0, 1]);
 							}
 						} else {
@@ -162,12 +164,12 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 							mkm.dataObj.yTest.push(CURRTRIAL.sample_scenebag_label[0][0]);
 						}
 						// mkm.cvs SANITY CHECK CODE
-						// let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
-						// let cvsData = mkm.cvs.toDataURL();
-						// let path = (
-						// 	`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
-						// );
-						// mkmodelsRef.child(path).putString(cvsData, 'data_url');
+						let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
+						let cvsData = mkm.cvs.toDataURL();
+						let path = (
+							`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_sample.png`
+						);
+						mkmodelsRef.child(path).putString(cvsData, 'data_url');
 						// ctx2.clearRect(0, 0, EYETRACKERCANVAS.width, EYETRACKERCANVAS.height);
 						mkm.hasSampleFeatures = true;							
 					} else if (taskscreen == 'Test' && !mkm.hasTestFeatures) {
@@ -202,10 +204,12 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						if (CURRTRIAL.num <= TASK.ModelConfig.trainIdx) {
 							mkm.dataObj.xTrain.push(featureVec);
 							if (CURRTRIAL.test_scenebag_labels[0][0] == 0) {
+								mkm.dataObj.yTrainLabels.push(0);
 								mkm.dataObj.yTrain.push([1, 0]);
 								// for SVM
 								// mkm.dataObj.yTrain.push([-1])
 							} else if (CURRTRIAL.test_scenebag_labels[0][0] == 1) {
+								mkm.dataObj.yTrainLabels.push(1);
 								mkm.dataObj.yTrain.push([0, 1]);
 							}
 						} else {
@@ -214,12 +218,12 @@ function displayTrial(ti,gr,fr,sc,ob,id,mkm){
 						}
 
 						// mkm.cvs SANITY CHECK HERE
-						// let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
-						// let cvsData = mkm.cvs.toDataURL();
-						// let path = (
-						// 	`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_test.png`
-						// );
-						// mkmodelsRef.child(path).putString(cvsData, 'data_url');
+						let mkmodelsRef = storageRef.child('mkturkfiles/mkmodels/');
+						let cvsData = mkm.cvs.toDataURL();
+						let path = (
+							`${TASK.Agent}/${ENV.CurrentDate.toJSON()}/${CURRTRIAL.num}_test.png`
+						);
+						mkmodelsRef.child(path).putString(cvsData, 'data_url');
 						// ctx2.clearRect(0, 0, EYETRACKERCANVAS.width, EYETRACKERCANVAS.height);
 						mkm.hasTestFeatures = true;							
 					} else if (taskscreen == 'Choice' && mkm.hasSampleFeatures && mkm.hasTestFeatures) {

--- a/public/mkturk/mkturk_trialqueue_scene.js
+++ b/public/mkturk/mkturk_trialqueue_scene.js
@@ -31,91 +31,91 @@ async build(trial_cushion_size){
 	this.samplebag_labels = [];
 	this.samplebag_indices = [];
 	this.samplebag_paths = [];
-	for (let i = 0; i < IMAGES['Sample'].length; i++) {
-		// FOR i scene bags (labels)
-		for (let j = 0; j < IMAGES['Sample'][i].nimages; j++) {
-			// FOR j scene renders, assign label
-			this.samplebag_labels.push(i);
-			this.samplebag_indices.push(j);
-		}
-
-		if (IMAGES['Sample'][i].nbackgroundimages > 0) {
-			// get background images, if any
-			let imageBagPaths = (
-				await loadImageBagPathsParallelFirebase([IMAGES['Sample'][i].IMAGES.imagebag])
-			);
-			this.samplebag_paths[i] = imageBagPaths[0];
-		} else {
-			this.samplebag_paths[i] = [];
-		}
-	}
-
-	// for (var i=0; i <= IMAGES["Sample"].length-1; i++){
-	// 	for (var j=0; j<= IMAGES["Sample"][i].nimages-1; j++){
-	// 		this.samplebag_labels.push(i)
-	// 		this.samplebag_indices.push(j)
-	// 	} //for j scene renders, assign label
-
-	// 	//get background images, if any
-	// 	if (IMAGES["Sample"][i].nbackgroundimages > 0){
-	// 		var funcreturn = await loadImageBagPathsParallelFirebase([IMAGES["Sample"][i].IMAGES.imagebag]); 
-	// 		this.samplebag_paths[i] = funcreturn[0]; 
+	// for (let i = 0; i < IMAGES['Sample'].length; i++) {
+	// 	// FOR i scene bags (labels)
+	// 	for (let j = 0; j < IMAGES['Sample'][i].nimages; j++) {
+	// 		// FOR j scene renders, assign label
+	// 		this.samplebag_labels.push(i);
+	// 		this.samplebag_indices.push(j);
 	// 	}
-	// 	else {
-	// 		this.samplebag_paths[i] = []
+
+	// 	if (IMAGES['Sample'][i].nbackgroundimages > 0) {
+	// 		// get background images, if any
+	// 		let imageBagPaths = (
+	// 			await loadImageBagPathsParallelFirebase([IMAGES['Sample'][i].IMAGES.imagebag])
+	// 		);
+	// 		this.samplebag_paths[i] = imageBagPaths[0];
+	// 	} else {
+	// 		this.samplebag_paths[i] = [];
 	// 	}
-	// } //for i scene bags (labels)
-
-
-
-	this.samplebag_block_indices = [];
-	for (let i = 0; i < this.samplebag_labels.length; i++) {
-		this.samplebag_block_indices.push(i);
-	}
-
-	// this.samplebag_block_indices = new Array(this.samplebag_labels.length)
-	// for (var i = 0; i<=this.samplebag_labels.length-1; i++){
-	// 	this.samplebag_block_indices[i] = i;
 	// }
+
+	for (var i=0; i <= IMAGES["Sample"].length-1; i++){
+		for (var j=0; j<= IMAGES["Sample"][i].nimages-1; j++){
+			this.samplebag_labels.push(i)
+			this.samplebag_indices.push(j)
+		} //for j scene renders, assign label
+
+		//get background images, if any
+		if (IMAGES["Sample"][i].nbackgroundimages > 0){
+			var funcreturn = await loadImageBagPathsParallelFirebase([IMAGES["Sample"][i].IMAGES.imagebag]); 
+			this.samplebag_paths[i] = funcreturn[0]; 
+		}
+		else {
+			this.samplebag_paths[i] = []
+		}
+	} //for i scene bags (labels)
+
+
+
+	// this.samplebag_block_indices = [];
+	// for (let i = 0; i < this.samplebag_labels.length; i++) {
+	// 	this.samplebag_block_indices.push(i);
+	// }
+
+	this.samplebag_block_indices = new Array(this.samplebag_labels.length)
+	for (var i = 0; i<=this.samplebag_labels.length-1; i++){
+		this.samplebag_block_indices[i] = i;
+	}
 
 	this.testbag_labels = [];
 	this.testbag_paths = [];
 	this.testbag_indices = [];
 
 	// FOR i scene bags (labels)
-	for (let i = 0; i < IMAGES['Test'].length; i++) {
-		// FOR j scene renders, assign label
-		for (let j = 0; i < IMAGES['Test'][i].nimages; j++) {
-			this.testbag_labels.push(i);
-			this.testbag_indices.push(j);
-		}
-
-		// get background images, if any
-		if (IMAGES['Test'][i].nbackgroundimages > 0) {
-			let imageBagPaths = (
-				await loadImageBagPathsParallelFirebase([IMAGES['Test'][i].IMAGES.imagebag])
-			);
-			this.testbag_paths[i] = imageBagPaths[0];
-		} else {
-			this.testbag_paths[i] = [];
-		}
-	}
-
-	// for (var i=0; i <= IMAGES["Test"].length-1; i++){
-	// 	for (var j=0; j<= IMAGES["Test"][i].nimages-1; j++){
-	// 		this.testbag_labels.push(i)
-	// 		this.testbag_indices.push(j)
-	// 	} //for j scene renders, assign label
-
-	// 	//get background images, if any
-	// 	if (IMAGES["Test"][i].nbackgroundimages > 0){
-	// 		var funcreturn = await loadImageBagPathsParallelFirebase([IMAGES["Test"][i].IMAGES.imagebag]); 
-	// 		this.testbag_paths[i] = funcreturn[0]; 
+	// for (let i = 0; i < IMAGES['Test'].length; i++) {
+	// 	// FOR j scene renders, assign label
+	// 	for (let j = 0; i < IMAGES['Test'][i].nimages; j++) {
+	// 		this.testbag_labels.push(i);
+	// 		this.testbag_indices.push(j);
 	// 	}
-	// 	else {
-	// 		this.testbag_paths[i] = []
+
+	// 	// get background images, if any
+	// 	if (IMAGES['Test'][i].nbackgroundimages > 0) {
+	// 		let imageBagPaths = (
+	// 			await loadImageBagPathsParallelFirebase([IMAGES['Test'][i].IMAGES.imagebag])
+	// 		);
+	// 		this.testbag_paths[i] = imageBagPaths[0];
+	// 	} else {
+	// 		this.testbag_paths[i] = [];
 	// 	}
-	// } //for i scene bags (labels)
+	// }
+
+	for (var i=0; i <= IMAGES["Test"].length-1; i++){
+		for (var j=0; j<= IMAGES["Test"][i].nimages-1; j++){
+			this.testbag_labels.push(i)
+			this.testbag_indices.push(j)
+		} //for j scene renders, assign label
+
+		//get background images, if any
+		if (IMAGES["Test"][i].nbackgroundimages > 0){
+			var funcreturn = await loadImageBagPathsParallelFirebase([IMAGES["Test"][i].IMAGES.imagebag]); 
+			this.testbag_paths[i] = funcreturn[0]; 
+		}
+		else {
+			this.testbag_paths[i] = []
+		}
+	} //for i scene bags (labels)
 
 	for (let i = 0; i < this.samplebag_indices.length; i++) {
 		this.samplebucket.push(i);

--- a/public/mkturk/mkturk_trialqueue_scene.js
+++ b/public/mkturk/mkturk_trialqueue_scene.js
@@ -31,48 +31,94 @@ async build(trial_cushion_size){
 	this.samplebag_labels = [];
 	this.samplebag_indices = [];
 	this.samplebag_paths = [];
-	for (var i=0; i <= IMAGES["Sample"].length-1; i++){
-		for (var j=0; j<= IMAGES["Sample"][i].nimages-1; j++){
-			this.samplebag_labels.push(i)
-			this.samplebag_indices.push(j)
-		} //for j scene renders, assign label
-
-		//get background images, if any
-		if (IMAGES["Sample"][i].nbackgroundimages > 0){
-			var funcreturn = await loadImageBagPathsParallelFirebase([IMAGES["Sample"][i].IMAGES.imagebag]); 
-			this.samplebag_paths[i] = funcreturn[0]; 
+	for (let i = 0; i < IMAGES['Sample'].length; i++) {
+		// FOR i scene bags (labels)
+		for (let j = 0; j < IMAGES['Sample'][i].nimages; j++) {
+			// FOR j scene renders, assign label
+			this.samplebag_labels.push(i);
+			this.samplebag_indices.push(j);
 		}
-		else {
-			this.samplebag_paths[i] = []
-		}
-	} //for i scene bags (labels)
 
-	this.samplebag_block_indices = new Array(this.samplebag_labels.length)
-	for (var i = 0; i<=this.samplebag_labels.length-1; i++){
-		this.samplebag_block_indices[i] = i;
+		if (IMAGES['Sample'][i].nbackgroundimages > 0) {
+			// get background images, if any
+			let imageBagPaths = (
+				await loadImageBagPathsParallelFirebase([IMAGES['Sample'][i].IMAGES.imagebag])
+			);
+			this.samplebag_paths[i] = imageBagPaths[0];
+		} else {
+			this.samplebag_paths[i] = [];
+		}
 	}
+
+	// for (var i=0; i <= IMAGES["Sample"].length-1; i++){
+	// 	for (var j=0; j<= IMAGES["Sample"][i].nimages-1; j++){
+	// 		this.samplebag_labels.push(i)
+	// 		this.samplebag_indices.push(j)
+	// 	} //for j scene renders, assign label
+
+	// 	//get background images, if any
+	// 	if (IMAGES["Sample"][i].nbackgroundimages > 0){
+	// 		var funcreturn = await loadImageBagPathsParallelFirebase([IMAGES["Sample"][i].IMAGES.imagebag]); 
+	// 		this.samplebag_paths[i] = funcreturn[0]; 
+	// 	}
+	// 	else {
+	// 		this.samplebag_paths[i] = []
+	// 	}
+	// } //for i scene bags (labels)
+
+
+
+	this.samplebag_block_indices = [];
+	for (let i = 0; i < this.samplebag_labels.length; i++) {
+		this.samplebag_block_indices.push(i);
+	}
+
+	// this.samplebag_block_indices = new Array(this.samplebag_labels.length)
+	// for (var i = 0; i<=this.samplebag_labels.length-1; i++){
+	// 	this.samplebag_block_indices[i] = i;
+	// }
 
 	this.testbag_labels = [];
 	this.testbag_paths = [];
 	this.testbag_indices = [];
-	for (var i=0; i <= IMAGES["Test"].length-1; i++){
-		for (var j=0; j<= IMAGES["Test"][i].nimages-1; j++){
-			this.testbag_labels.push(i)
-			this.testbag_indices.push(j)
-		} //for j scene renders, assign label
 
-		//get background images, if any
-		if (IMAGES["Test"][i].nbackgroundimages > 0){
-			var funcreturn = await loadImageBagPathsParallelFirebase([IMAGES["Test"][i].IMAGES.imagebag]); 
-			this.testbag_paths[i] = funcreturn[0]; 
+	// FOR i scene bags (labels)
+	for (let i = 0; i < IMAGES['Test'].length; i++) {
+		// FOR j scene renders, assign label
+		for (let j = 0; i < IMAGES['Test'][i].nimages; j++) {
+			this.testbag_labels.push(i);
+			this.testbag_indices.push(j);
 		}
-		else {
-			this.testbag_paths[i] = []
-		}
-	} //for i scene bags (labels)
 
-	for (var i=0; i<=this.samplebag_indices.length-1; i++){
-		this.samplebucket.push(i)
+		// get background images, if any
+		if (IMAGES['Test'][i].nbackgroundimages > 0) {
+			let imageBagPaths = (
+				await loadImageBagPathsParallelFirebase([IMAGES['Test'][i].IMAGES.imagebag])
+			);
+			this.testbag_paths[i] = imageBagPaths[0];
+		} else {
+			this.testbag_paths[i] = [];
+		}
+	}
+
+	// for (var i=0; i <= IMAGES["Test"].length-1; i++){
+	// 	for (var j=0; j<= IMAGES["Test"][i].nimages-1; j++){
+	// 		this.testbag_labels.push(i)
+	// 		this.testbag_indices.push(j)
+	// 	} //for j scene renders, assign label
+
+	// 	//get background images, if any
+	// 	if (IMAGES["Test"][i].nbackgroundimages > 0){
+	// 		var funcreturn = await loadImageBagPathsParallelFirebase([IMAGES["Test"][i].IMAGES.imagebag]); 
+	// 		this.testbag_paths[i] = funcreturn[0]; 
+	// 	}
+	// 	else {
+	// 		this.testbag_paths[i] = []
+	// 	}
+	// } //for i scene bags (labels)
+
+	for (let i = 0; i < this.samplebag_indices.length; i++) {
+		this.samplebucket.push(i);
 	}
 
 	// array of zeros


### PR DESCRIPTION
MkModels has been updated to be more robust.

Changes include:

- more robust boundingBox generation for MkModels
- MkModels can now run SameDifferent task
- Inferring most model parameters needed to run a task

In slightly more detail:

1. MkModels utilizes a HTMLCanvasElement as an input to a feature extractor (i.e. ResNet50). But because most feature extractors hosted on [Tensorflow Hub](https://tfhub.dev) require the input to be of size 224 x 224 pixels, additional work must be done to _crop_ and _capture_ what is being shown on ```VISIBLECANVAS``` onto a HTMLCanvasElement used by MkModels. When a Sample presentation includes a background image, the solution is to simply take the boundingBox of the background image. However, when a Sample presentation (and Test in the case of SameDifferent task) lacks a background image, there are opportunities for many different schemes. This version of MkModels calculates the midpoint of an image or a face using ```boundingBoxesChoice3D``` provided by ```mkturk_screenfunctions.js```. Then it calculates the width and height of the cropping box using the ```sizeInches``` variable of each object or face. In the case where object's ```sizeInches``` variable points to an array, MkModels takes the maximum size value residing in the array. The reason for this is to avoid normalizing the size of the array based on it's own size. Specifically, taking the maximum size value allows an object/face that was intended to appear larger is actually larger. Once the coordinates and the size of the cropping box is set, the captured box is downsampled to 224 x 224. 

2. When MkModels runs on a SameDifferent task, it trains on both the Sample and Test images. So if you set TASK.ModelConfig.trainIdx = 100, then during SameDifferent task, the model will actually train on 200 images. During testing phase, MkModels will output prediction on both Sample and Test images. Response will be recorded as **Same** if the class prediction for Sample and Test images are the same and **Different** otherwise.

3. In ```Default``` mode of MkModels (configured by setting TASK.ModelConfig.mode = 'default'), the only parameters needed to run a model are:
![image](https://user-images.githubusercontent.com/20652714/110738503-6ff57b80-81fd-11eb-8455-6a06ae7aa8c3.png)
There exists an ```Advanced``` mode with experimental features such as customizing some model parameters, specifying training scenes from those listed in ```TASK.ImageBagsSample```, different ways to save images used during training and/or testing phase but as they have not been tested for robust usage, if you require a more customizable MkModels experience, please let me know and I'll see if it is possible in this version of MkModels.